### PR TITLE
add unit test coverage

### DIFF
--- a/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkWriteSummarizer.java
+++ b/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkWriteSummarizer.java
@@ -32,7 +32,8 @@ public class PerThreadNetworkWriteSummarizer implements EventToSummary {
 
     @Override
     public void accept(RecordedEvent ev) {
-        endTimeMs = ev.getStartTime().toEpochMilli();
+        var duration = ev.getDuration();
+        endTimeMs = ev.getStartTime().plus(duration).toEpochMilli();
         count++;
         var bytesWritten = ev.getLong("bytesWritten");
         bytes = bytes + bytesWritten;
@@ -44,14 +45,13 @@ public class PerThreadNetworkWriteSummarizer implements EventToSummary {
             minBytes = bytesWritten;
         }
 
-        var du = ev.getDuration();
-        duration = duration.plus(du);
+        this.duration = this.duration.plus(duration);
 
-        if (du.compareTo(maxDuration) > 0) {
-            maxDuration = du;
+        if (duration.compareTo(maxDuration) > 0) {
+            maxDuration = duration;
         }
-        if (du.compareTo(minDuration) < 0) {
-            minDuration = du;
+        if (duration.compareTo(minDuration) < 0) {
+            minDuration = duration;
         }
     }
 

--- a/src/test/java/com/newrelic/jfr/tosummary/NetworkWriteSummarizerTest.java
+++ b/src/test/java/com/newrelic/jfr/tosummary/NetworkWriteSummarizerTest.java
@@ -1,0 +1,79 @@
+package com.newrelic.jfr.tosummary;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.metrics.Summary;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NetworkWriteSummarizerTest {
+
+    @Test
+    void testApply() {
+        var threadName1 = "spam";
+        var threadName2 = "musubi";
+        var time1 = Instant.now();
+        var time2 = time1.plus(3, SECONDS);
+        var time3 = time2.plus(1, SECONDS);
+
+        var summary1bytes = new Summary("jfr:SocketWrite.bytesWritten", 2, 13 + 17, 13, 17,
+                time1.toEpochMilli(), time3.toEpochMilli(),
+                new Attributes().put("thread.name", threadName1)
+        );
+        var summary1duration = new Summary("jfr:SocketWrite.duration", 2,
+                Duration.between(time1, time3).toMillis(),
+                Duration.between(time2, time3).toMillis(),
+                Duration.between(time1, time2).toMillis(),
+                time1.toEpochMilli(), time3.toEpochMilli(),
+                new Attributes().put("thread.name", threadName1)
+        );
+        var summary2bytes = new Summary("jfr:SocketWrite.bytesWritten", 1, 12, 12, 12,
+                time2.toEpochMilli(), time3.toEpochMilli(),
+                new Attributes().put("thread.name", threadName2)
+        );
+        var summary2duration = new Summary("jfr:SocketWrite.duration", 1,
+                Duration.between(time2, time3).toMillis(),
+                Duration.between(time2, time3).toMillis(),
+                Duration.between(time2, time3).toMillis(),
+                time2.toEpochMilli(), time3.toEpochMilli(),
+                new Attributes().put("thread.name", threadName2)
+        );
+        List<Summary> expected = List.of(summary2bytes, summary2duration, summary1bytes, summary1duration);
+
+        var event1 = buildEvent(threadName1, 13, time1, time2);
+        var event2 = buildEvent(threadName2, 12, time2, time3);
+        var event3 = buildEvent(threadName1, 17, time2, time3);
+
+        NetworkWriteSummarizer summarizer = new NetworkWriteSummarizer();
+        summarizer.accept(event1);
+        summarizer.accept(event2);
+        summarizer.accept(event3);
+
+        var result = summarizer.summarizeAndReset();
+
+        assertEquals(expected, result.collect(toList()));
+    }
+
+    private RecordedEvent buildEvent(String threadName, long bytes, Instant startTime, Instant endTime) {
+        var recordedThread = mock(RecordedThread.class);
+        when(recordedThread.getJavaName()).thenReturn(threadName);
+
+        var event = mock(RecordedEvent.class);
+        when(event.getValue("eventThread")).thenReturn(recordedThread);
+        when(event.getLong("bytesWritten")).thenReturn(bytes);
+        when(event.getStartTime()).thenReturn(startTime);
+        when(event.getDuration()).thenReturn(Duration.between(startTime, endTime));
+        return event;
+    }
+
+}


### PR DESCRIPTION
This contains the same duration fix that the SocketRead version had in #6, but with SocketWrite now.

You might notice that this is a copy/paste of the read test and, while not ideal, is intentional at this time.  I think it helps to call out the duplication between the read/write sides...and that's a task that can be tackled with a future PR.