### PR TITLE
Initial actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
@@ -20,4 +18,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,15 +10,16 @@ repositories {
 
 plugins {
     id("java-library")
+    `maven-publish`
 }
 
-group = "com.newrelic.telemetry"
+group = "com.newrelic"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
     disableAutoTargetJvm()
-	withSourcesJar()
+    withSourcesJar()
 }
 
 dependencies {
@@ -33,5 +34,35 @@ tasks.test {
     useJUnitPlatform()
     testLogging {
         events("passed", "skipped", "failed")
+    }
+}
+
+tasks {
+    val taskScope = this
+    val jar: Jar by taskScope
+    jar.apply {
+        manifest.attributes["Implementation-Version"] = project.version
+        manifest.attributes["Implementation-Vendor"] = "New Relic, Inc"
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+            credentials {
+                username = System.getenv("SONATYPE_USERNAME")
+                password = System.getenv("SONATYPE_PASSWORD")
+            }
+        }
+    }
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "com.newrelic"
+            artifactId = "jfr-mappers"
+            version = version
+        }
     }
 }


### PR DESCRIPTION
The build action runs locally using `act`...but publish won't work correctly until we set up credentials.  Those will need to happen after the repo goes public.