### PR TITLE
Fix overflow tests

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
@@ -67,7 +67,20 @@ public final class MethodSupport {
       // Truncate the stack frame and try again
       double percentageOfFramesToTry = ((double) HEADROOM_75PC) / length;
       int numFrames = (int) (frameCount * percentageOfFramesToTry);
-      return jsonWrite(frames, Optional.of(numFrames));
+      if (numFrames < frameCount) {
+        return jsonWrite(frames, Optional.of(numFrames));
+      }
+      throw new IOException(
+          "Corner case of a stack frame that can't be cleanly truncated! "
+              + "numFrames = "
+              + numFrames
+              + ", frameCount = "
+              + frameCount
+              + ", "
+              + ", percentageOfFramesToTry = "
+              + percentageOfFramesToTry
+              + ", length = "
+              + length);
     } else {
       return out;
     }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
@@ -66,7 +66,7 @@ public final class MethodSupport {
     if (length > HEADROOM_75PC) {
       // Truncate the stack frame and try again
       double percentageOfFramesToTry = ((double) HEADROOM_75PC) / length;
-      int numFrames = (int) (frames.size() * percentageOfFramesToTry);
+      int numFrames = (int) (frameCount * percentageOfFramesToTry);
       if (numFrames < frameCount) {
         return jsonWrite(frames, Optional.of(numFrames));
       }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
@@ -67,11 +67,7 @@ public final class MethodSupport {
       // Truncate the stack frame and try again
       double percentageOfFramesToTry = ((double) HEADROOM_75PC) / length;
       int numFrames = (int) (frameCount * percentageOfFramesToTry);
-      if (numFrames < frameCount) {
-        return jsonWrite(frames, Optional.of(numFrames));
-      }
-      throw new IOException(
-          "Corner case of a stack frame that can't be cleanly truncated, should not happen in practice");
+      return jsonWrite(frames, Optional.of(numFrames));
     } else {
       return out;
     }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
@@ -43,10 +43,8 @@ public final class MethodSupport {
     var strOut = new StringWriter();
     var jsonWriter = new JsonWriter(strOut);
     var isTruncated = limit.isPresent();
-    var frameCount = frames.size();
-    if (isTruncated && limit.get() < frameCount) {
-      frameCount = limit.get();
-    }
+    var frameCount = Math.min(limit.orElse(frames.size()), frames.size());
+
     jsonWriter.beginObject();
     jsonWriter.name("type").value("stacktrace");
     jsonWriter.name("language").value("java");

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
@@ -42,14 +42,13 @@ public final class MethodSupport {
       throws IOException {
     var strOut = new StringWriter();
     var jsonWriter = new JsonWriter(strOut);
-    var isTruncated = limit.isPresent();
     var frameCount = Math.min(limit.orElse(frames.size()), frames.size());
 
     jsonWriter.beginObject();
     jsonWriter.name("type").value("stacktrace");
     jsonWriter.name("language").value("java");
     jsonWriter.name("version").value(JSON_SCHEMA_VERSION);
-    jsonWriter.name("truncated").value(isTruncated);
+    jsonWriter.name("truncated").value(frameCount < frames.size());
     jsonWriter.name("payload").beginArray();
     for (int i = 0; i < frameCount; i++) {
       var frame = frames.get(i);

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
@@ -2,7 +2,6 @@ package com.newrelic.jfr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -16,7 +15,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import jdk.jfr.consumer.RecordingFile;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -94,7 +92,10 @@ public class MethodSupportTest {
     List<Map<String, String>> stack = new ArrayList<>();
     stack.add(buildFrame("action", "21", "77"));
     String payload = "{\"desc\":\"action\",\"line\":\"21\",\"bytecodeIndex\":\"77\"}";
-    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":false,\"payload\":[" + payload + "]}";
+    var expected =
+        "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":false,\"payload\":["
+            + payload
+            + "]}";
     var result = MethodSupport.jsonWrite(stack, Optional.empty());
     assertEquals(expected, result);
   }
@@ -104,7 +105,10 @@ public class MethodSupportTest {
     List<Map<String, String>> stack = new ArrayList<>();
     stack.add(buildFrame("action", "21", "77"));
     String payload = "{\"desc\":\"action\",\"line\":\"21\",\"bytecodeIndex\":\"77\"}";
-    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":false,\"payload\":[" + payload + "]}";
+    var expected =
+        "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":false,\"payload\":["
+            + payload
+            + "]}";
     var result = MethodSupport.jsonWrite(stack, Optional.of(1));
     assertEquals(expected, result);
   }
@@ -117,8 +121,12 @@ public class MethodSupportTest {
     stack.add(buildFrame("action3", "23", "79"));
     String payload1 = "{\"desc\":\"action1\",\"line\":\"21\",\"bytecodeIndex\":\"77\"}";
     String payload2 = "{\"desc\":\"action2\",\"line\":\"22\",\"bytecodeIndex\":\"78\"}";
-    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":[" +
-            payload1 + "," + payload2 + "]}";
+    var expected =
+        "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":["
+            + payload1
+            + ","
+            + payload2
+            + "]}";
     var result = MethodSupport.jsonWrite(stack, Optional.of(2));
     assertEquals(expected, result);
   }
@@ -126,15 +134,26 @@ public class MethodSupportTest {
   @Test
   void writeLargeStack() throws Exception {
     List<Map<String, String>> stack = new ArrayList<>();
-    for(int i=0; i < 500; i++){
+    for (int i = 0; i < 500; i++) {
       stack.add(buildFrame(i));
     }
 
-    String payloads = IntStream.range(0, 55).mapToObj(i ->
-            "{\"desc\":\"action" + i + "\",\"line\":\"" + (21 + i) +
-            "\",\"bytecodeIndex\":\"" + (77 + i) + "\"}").collect(Collectors.joining(","));
-    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":[" +
-            payloads + "]}";
+    String payloads =
+        IntStream.range(0, 55)
+            .mapToObj(
+                i ->
+                    "{\"desc\":\"action"
+                        + i
+                        + "\",\"line\":\""
+                        + (21 + i)
+                        + "\",\"bytecodeIndex\":\""
+                        + (77 + i)
+                        + "\"}")
+            .collect(Collectors.joining(","));
+    var expected =
+        "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":["
+            + payloads
+            + "]}";
     var result = MethodSupport.jsonWrite(stack, Optional.empty());
     assertEquals(expected, result);
   }
@@ -144,7 +163,7 @@ public class MethodSupportTest {
     List<Map<String, String>> stack = new ArrayList<>();
     // Specially crafted artisanal length in order to exercise the edge case
     // It happens on the second recursion.
-    for(int i=0; i < 75; i++){
+    for (int i = 0; i < 75; i++) {
       var frame = Map.of("desc", "", "line", "", "bytecodeIndex", "");
       stack.add(frame);
     }
@@ -154,7 +173,7 @@ public class MethodSupportTest {
     assertTrue(result.length() < 3 * 1024);
   }
 
-  private Map<String, String> buildFrame(int i){
+  private Map<String, String> buildFrame(int i) {
     return buildFrame("action" + i, "" + (21 + i), "" + (77 + i));
   }
 

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
@@ -1,6 +1,7 @@
 package com.newrelic.jfr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -9,8 +10,12 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import jdk.jfr.consumer.RecordingFile;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -81,5 +86,67 @@ public class MethodSupportTest {
     assertEquals(3994, histo[5]);
     assertEquals(766, histo[6]);
     assertEquals(195, histo[7]); // 99.87% fit in 2 * 4k
+  }
+
+  @Test
+  void writeJsonSimple_noLimit() throws Exception {
+    List<Map<String, String>> stack = new ArrayList<>();
+    stack.add(buildFrame("action", "21", "77"));
+    String payload = "{\"desc\":\"action\",\"line\":\"21\",\"bytecodeIndex\":\"77\"}";
+    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":false,\"payload\":[" + payload + "]}";
+    var result = MethodSupport.jsonWrite(stack, Optional.empty());
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void writeJsonSimple_withLimit() throws Exception {
+    List<Map<String, String>> stack = new ArrayList<>();
+    stack.add(buildFrame("action1", "21", "77"));
+    stack.add(buildFrame("action2", "22", "78"));
+    stack.add(buildFrame("action3", "23", "79"));
+    String payload1 = "{\"desc\":\"action1\",\"line\":\"21\",\"bytecodeIndex\":\"77\"}";
+    String payload2 = "{\"desc\":\"action2\",\"line\":\"22\",\"bytecodeIndex\":\"78\"}";
+    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":[" +
+            payload1 + "," + payload2 + "]}";
+    var result = MethodSupport.jsonWrite(stack, Optional.of(2));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void writeLargeStack() throws Exception {
+    List<Map<String, String>> stack = new ArrayList<>();
+    for(int i=0; i < 500; i++){
+      stack.add(buildFrame(i));
+    }
+
+    String payloads = IntStream.range(0, 55).mapToObj(i ->
+            "{\"desc\":\"action" + i + "\",\"line\":\"" + (21 + i) +
+            "\",\"bytecodeIndex\":\"" + (77 + i) + "\"}").collect(Collectors.joining(","));
+    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":[" +
+            payloads + "]}";
+    var result = MethodSupport.jsonWrite(stack, Optional.empty());
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void writeLargeStack_edgeCase() {
+    List<Map<String, String>> stack = new ArrayList<>();
+    // Specially crafted artisanal length in order to exercise the edge case
+    // It happens on the second recursion.
+    for(int i=0; i < 75; i++){
+      var frame = Map.of("desc", "", "line", "", "bytecodeIndex", "");
+      stack.add(frame);
+    }
+    assertThrows(IOException.class, () -> {
+      MethodSupport.jsonWrite(stack, Optional.of(74));
+    });
+  }
+
+  private Map<String, String> buildFrame(int i){
+    return buildFrame("action" + i, "" + (21 + i), "" + (77 + i));
+  }
+
+  private Map<String, String> buildFrame(String desc, String line, String bytecodeIndex) {
+    return Map.of("desc", desc, "line", line, "bytecodeIndex", bytecodeIndex);
   }
 }

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
@@ -99,6 +99,16 @@ public class MethodSupportTest {
   }
 
   @Test
+  void writeJsonSimple_limitMatchesFrameSize() throws Exception {
+    List<Map<String, String>> stack = new ArrayList<>();
+    stack.add(buildFrame("action", "21", "77"));
+    String payload = "{\"desc\":\"action\",\"line\":\"21\",\"bytecodeIndex\":\"77\"}";
+    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":[" + payload + "]}";
+    var result = MethodSupport.jsonWrite(stack, Optional.of(1));
+    assertEquals(expected, result);
+  }
+
+  @Test
   void writeJsonSimple_withLimit() throws Exception {
     List<Map<String, String>> stack = new ArrayList<>();
     stack.add(buildFrame("action1", "21", "77"));

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
@@ -99,11 +99,11 @@ public class MethodSupportTest {
   }
 
   @Test
-  void writeJsonSimple_limitMatchesFrameSize() throws Exception {
+  void writeJsonSimple_limitMatchesFrameCount() throws Exception {
     List<Map<String, String>> stack = new ArrayList<>();
     stack.add(buildFrame("action", "21", "77"));
     String payload = "{\"desc\":\"action\",\"line\":\"21\",\"bytecodeIndex\":\"77\"}";
-    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":true,\"payload\":[" + payload + "]}";
+    var expected = "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":false,\"payload\":[" + payload + "]}";
     var result = MethodSupport.jsonWrite(stack, Optional.of(1));
     assertEquals(expected, result);
   }

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/MethodSupportTest.java
@@ -1,6 +1,7 @@
 package com.newrelic.jfr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -139,7 +140,7 @@ public class MethodSupportTest {
   }
 
   @Test
-  void writeLargeStack_edgeCase() {
+  void writeLargeStack_edgeCase() throws Exception {
     List<Map<String, String>> stack = new ArrayList<>();
     // Specially crafted artisanal length in order to exercise the edge case
     // It happens on the second recursion.
@@ -147,9 +148,10 @@ public class MethodSupportTest {
       var frame = Map.of("desc", "", "line", "", "bytecodeIndex", "");
       stack.add(frame);
     }
-    assertThrows(IOException.class, () -> {
-      MethodSupport.jsonWrite(stack, Optional.of(74));
-    });
+
+    String result = MethodSupport.jsonWrite(stack, Optional.of(74));
+    assertNotNull(result);
+    assertTrue(result.length() < 3 * 1024);
   }
 
   private Map<String, String> buildFrame(int i){


### PR DESCRIPTION
Added some tests to the fix overflow PR, but did it as a new branch to facilitate easier step-by-step reviewing.  I think it'll make the most sense to go commit by commit to see what I did at each point.

I was able to craft a test that exercised the `IOException` edge case.  I the fixed the code and broke the passing test and then removed the exception.

The short story is that I think that the edge case was due to an error -- we were using the size of the stack frames map to determine the new limit, instead of using the computed desired frame count.  I removed the conditional and exception because it truly shouldn't happen anymore.  😉 