### PR TITLE
Fallback for localIpAddr failure

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
@@ -142,7 +142,13 @@ public final class JFRController {
 
   static JFRUploader buildUploader(DaemonConfig config)
       throws UnknownHostException, MalformedURLException {
-    String localIpAddr = InetAddress.getLocalHost().toString();
+    String localIpAddr;
+    try {
+      localIpAddr = InetAddress.getLocalHost().toString();
+    } catch (Throwable e) {
+      logger.error("Unable to get localhost IP, defaulting to 127.0.0.1.", e);
+      localIpAddr = "127.0.0.1";
+    }
     var attr =
         COMMON_ATTRIBUTES
             .put(APP_NAME, config.getMonitoredAppName())

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
@@ -147,7 +147,7 @@ public final class JFRController {
       localIpAddr = InetAddress.getLocalHost().toString();
     } catch (Throwable e) {
       logger.error("Unable to get localhost IP, defaulting to 127.0.0.1.", e);
-      localIpAddr = "127.0.0.1";
+      localIpAddr = InetAddress.getLoopbackAddress();
     }
     var attr =
         COMMON_ATTRIBUTES

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
@@ -146,8 +146,12 @@ public final class JFRController {
     try {
       localIpAddr = InetAddress.getLocalHost().toString();
     } catch (Throwable e) {
-      logger.error("Unable to get localhost IP, defaulting to 127.0.0.1.", e);
-      localIpAddr = InetAddress.getLoopbackAddress();
+      logger.error(
+          "Unable to get localhost IP, defaulting to loopback address,"
+              + InetAddress.getLoopbackAddress().toString()
+              + ".",
+          e);
+      localIpAddr = InetAddress.getLoopbackAddress().toString();
     }
     var attr =
         COMMON_ATTRIBUTES

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
@@ -42,16 +42,13 @@ public final class MethodSupport {
       throws IOException {
     var strOut = new StringWriter();
     var jsonWriter = new JsonWriter(strOut);
-    var isTruncated = limit.isPresent();
-    var frameCount = frames.size();
-    if (isTruncated && limit.get() < frameCount) {
-      frameCount = limit.get();
-    }
+    var frameCount = Math.min(limit.orElse(frames.size()), frames.size());
+
     jsonWriter.beginObject();
     jsonWriter.name("type").value("stacktrace");
     jsonWriter.name("language").value("java");
     jsonWriter.name("version").value(JSON_SCHEMA_VERSION);
-    jsonWriter.name("truncated").value(isTruncated);
+    jsonWriter.name("truncated").value(frameCount < frames.size());
     jsonWriter.name("payload").beginArray();
     for (int i = 0; i < frameCount; i++) {
       var frame = frames.get(i);
@@ -68,8 +65,22 @@ public final class MethodSupport {
     var length = out.length();
     if (length > HEADROOM_75PC) {
       // Truncate the stack frame and try again
-      int numFrames = frames.size() * HEADROOM_75PC / length;
-      return jsonWrite(frames, Optional.of(numFrames));
+      double percentageOfFramesToTry = ((double) HEADROOM_75PC) / length;
+      int numFrames = (int) (frameCount * percentageOfFramesToTry);
+      if (numFrames < frameCount) {
+        return jsonWrite(frames, Optional.of(numFrames));
+      }
+      throw new IOException(
+          "Corner case of a stack frame that can't be cleanly truncated! "
+              + "numFrames = "
+              + numFrames
+              + ", frameCount = "
+              + frameCount
+              + ", "
+              + ", percentageOfFramesToTry = "
+              + percentageOfFramesToTry
+              + ", length = "
+              + length);
     } else {
       return out;
     }


### PR DESCRIPTION
When running the JFR daemon in an Ubuntu or Alpine container on an Amazon EC2 instance, the JRE inside the container can't resolve the short hostname it receives to do a reverse DNS lookup. This detects failure of `getLocalHost()` and just puts in a localhost IP address.

You probably don't want to accept this PR, since it has a hard-coded IP address in it. I'd love to see how _you'd_ do the same thing.