### PR TITLE
guard against null thread

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapper.java
@@ -15,8 +15,10 @@ public class ThreadAllocationStatisticsMapper implements EventToMetric {
     var time = ev.getStartTime().toEpochMilli();
     var allocated = ev.getDouble("allocated");
     RecordedThread t = ev.getValue("thread");
-    var attr =
-        new Attributes().put("thread.name", t.getJavaName()).put("thread.osName", t.getOSName());
+    var attr = new Attributes();
+    if (t != null) {
+      attr.put("thread.name", t.getJavaName()).put("thread.osName", t.getOSName());
+    }
 
     return List.of(new Gauge("jfr:ThreadAllocationStatistics.allocated", allocated, time, attr));
   }

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapperTest.java
@@ -41,4 +41,25 @@ class ThreadAllocationStatisticsMapperTest {
     var result = testClass.apply(recordedEvent);
     assertEquals(expected, result);
   }
+
+  @Test
+  void nullThread() {
+    var recordedEvent = mock(RecordedEvent.class);
+    var now = System.currentTimeMillis();
+    var startTime = Instant.ofEpochMilli(now);
+    var allocated = 1250229920d;
+
+    var attr = new Attributes();
+    var gauge = new Gauge("jfr:ThreadAllocationStatistics.allocated", allocated, now, attr);
+    var expected = List.of(gauge);
+
+    var testClass = new ThreadAllocationStatisticsMapper();
+
+    when(recordedEvent.getStartTime()).thenReturn(startTime);
+    when(recordedEvent.getDouble("allocated")).thenReturn(allocated);
+    when(recordedEvent.getValue("thread")).thenReturn(null);
+
+    var result = testClass.apply(recordedEvent);
+    assertEquals(expected, result);
+  }
 }


### PR DESCRIPTION
We have observed at least one JVM in the wild that, under some circumstance, returns null for the thread field.  

In that rare case, let's just guard against that and return just the allocation data without thread identifiers.