### PR TITLE
No app name if agent

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRCommonAttributes.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRCommonAttributes.java
@@ -7,14 +7,6 @@
 
 package com.newrelic.jfr.daemon;
 
-import com.newrelic.telemetry.Attributes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Optional;
-
 import static com.newrelic.jfr.daemon.AttributeNames.APP_NAME;
 import static com.newrelic.jfr.daemon.AttributeNames.COLLECTOR_NAME;
 import static com.newrelic.jfr.daemon.AttributeNames.HOSTNAME;
@@ -22,62 +14,65 @@ import static com.newrelic.jfr.daemon.AttributeNames.INSTRUMENTATION_NAME;
 import static com.newrelic.jfr.daemon.AttributeNames.INSTRUMENTATION_PROVIDER;
 import static com.newrelic.jfr.daemon.AttributeNames.SERVICE_NAME;
 
+import com.newrelic.telemetry.Attributes;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class JFRCommonAttributes {
 
-    private static final Logger logger = LoggerFactory.getLogger(JFRCommonAttributes.class);
-    static final Attributes COMMON_ATTRIBUTES =
-            new Attributes()
-                    .put(INSTRUMENTATION_NAME, "JFR")
-                    .put(INSTRUMENTATION_PROVIDER, "JFR-Uploader")
-                    .put(COLLECTOR_NAME, "JFR-Uploader");
+  private static final Logger logger = LoggerFactory.getLogger(JFRCommonAttributes.class);
+  static final Attributes COMMON_ATTRIBUTES =
+      new Attributes()
+          .put(INSTRUMENTATION_NAME, "JFR")
+          .put(INSTRUMENTATION_PROVIDER, "JFR-Uploader")
+          .put(COLLECTOR_NAME, "JFR-Uploader");
 
-    private final DaemonConfig config;
-    private final HostInfo hostInfo;
+  private final DaemonConfig config;
+  private final HostInfo hostInfo;
 
-    public JFRCommonAttributes(DaemonConfig config) {
-        this(config, HostInfo.DEFAULT);
+  public JFRCommonAttributes(DaemonConfig config) {
+    this(config, HostInfo.DEFAULT);
+  }
+
+  JFRCommonAttributes(DaemonConfig config, HostInfo hostInfo) {
+    this.config = config;
+    this.hostInfo = hostInfo;
+  }
+
+  public Attributes build(Optional<String> entityGuid) {
+    var hostname = findHostname();
+    var attr =
+        COMMON_ATTRIBUTES.put(SERVICE_NAME, config.getMonitoredAppName()).put(HOSTNAME, hostname);
+    entityGuid.ifPresentOrElse(
+        guid -> attr.put("entity.guid", guid),
+        () -> attr.put(APP_NAME, config.getMonitoredAppName()));
+    return attr;
+  }
+
+  private String findHostname() {
+    try {
+      return hostInfo.getHost();
+    } catch (Throwable e) {
+      String loopback = hostInfo.getLoopback();
+      logger.error(
+          "Unable to get localhost IP, defaulting to loopback address," + loopback + ".", e);
+      return loopback;
+    }
+  }
+
+  interface HostInfo {
+
+    HostInfo DEFAULT = new HostInfo() {};
+
+    default String getLoopback() {
+      return InetAddress.getLoopbackAddress().toString();
     }
 
-    JFRCommonAttributes(DaemonConfig config, HostInfo hostInfo) {
-        this.config = config;
-        this.hostInfo = hostInfo;
+    default String getHost() throws UnknownHostException {
+      return InetAddress.getLocalHost().toString();
     }
-
-    public Attributes build(Optional<String> entityGuid){
-        var hostname = findHostname();
-        var attr =
-                COMMON_ATTRIBUTES
-                        .put(APP_NAME, config.getMonitoredAppName())
-                        .put(SERVICE_NAME, config.getMonitoredAppName())
-                        .put(HOSTNAME, hostname);
-        entityGuid.ifPresent(guid -> attr.put("entity.guid", guid));
-        return attr;
-    }
-
-    private String findHostname() {
-        try {
-            return hostInfo.getHost();
-        } catch (Throwable e) {
-            String loopback = hostInfo.getLoopback();
-            logger.error(
-                    "Unable to get localhost IP, defaulting to loopback address," + loopback + ".", e);
-            return loopback;
-        }
-    }
-
-    interface HostInfo {
-
-        HostInfo DEFAULT = new HostInfo(){};
-
-        default String getLoopback() {
-            return InetAddress.getLoopbackAddress().toString();
-        }
-
-        default String getHost() throws UnknownHostException {
-            return InetAddress.getLocalHost().toString();
-        }
-    }
-
-
-
+  }
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRCommonAttributes.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRCommonAttributes.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.jfr.daemon;
+
+import com.newrelic.telemetry.Attributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.util.Optional;
+
+import static com.newrelic.jfr.daemon.AttributeNames.APP_NAME;
+import static com.newrelic.jfr.daemon.AttributeNames.COLLECTOR_NAME;
+import static com.newrelic.jfr.daemon.AttributeNames.HOSTNAME;
+import static com.newrelic.jfr.daemon.AttributeNames.INSTRUMENTATION_NAME;
+import static com.newrelic.jfr.daemon.AttributeNames.INSTRUMENTATION_PROVIDER;
+import static com.newrelic.jfr.daemon.AttributeNames.SERVICE_NAME;
+
+public class JFRCommonAttributes {
+
+    private static final Logger logger = LoggerFactory.getLogger(JFRCommonAttributes.class);
+    private static final Attributes COMMON_ATTRIBUTES =
+            new Attributes()
+                    .put(INSTRUMENTATION_NAME, "JFR")
+                    .put(INSTRUMENTATION_PROVIDER, "JFR-Uploader")
+                    .put(COLLECTOR_NAME, "JFR-Uploader");
+    private final DaemonConfig config;
+
+    public JFRCommonAttributes(DaemonConfig config) {
+        this.config = config;
+    }
+
+    public Attributes build(Optional<String> entityGuid){
+        var hostname = findHostname();
+        var attr =
+                COMMON_ATTRIBUTES
+                        .put(APP_NAME, config.getMonitoredAppName())
+                        .put(SERVICE_NAME, config.getMonitoredAppName())
+                        .put(HOSTNAME, hostname);
+        entityGuid.ifPresent(guid -> attr.put("entity.guid", guid));
+        return attr;
+    }
+
+    private static String findHostname() {
+        try {
+            return InetAddress.getLocalHost().toString();
+        } catch (Throwable e) {
+            var loopback = InetAddress.getLoopbackAddress().toString();
+            logger.error(
+                    "Unable to get localhost IP, defaulting to loopback address," + loopback + ".", e);
+            return loopback;
+        }
+    }
+
+
+}

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
@@ -7,9 +7,21 @@
 
 package com.newrelic.jfr.daemon;
 
-import static com.newrelic.jfr.daemon.AttributeNames.APP_NAME;
-import static com.newrelic.jfr.daemon.AttributeNames.HOSTNAME;
-import static com.newrelic.jfr.daemon.AttributeNames.SERVICE_NAME;
+import com.newrelic.jfr.ToEventRegistry;
+import com.newrelic.jfr.ToMetricRegistry;
+import com.newrelic.jfr.ToSummaryRegistry;
+import com.newrelic.jfr.daemon.lifecycle.MBeanServerConnector;
+import com.newrelic.jfr.daemon.lifecycle.RemoteEntityGuid;
+import jdk.jfr.consumer.RecordedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.MBeanServerConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import static com.newrelic.jfr.daemon.EnvironmentVars.ENV_APP_NAME;
 import static com.newrelic.jfr.daemon.EnvironmentVars.EVENTS_INGEST_URI;
 import static com.newrelic.jfr.daemon.EnvironmentVars.INSERT_API_KEY;
@@ -17,23 +29,7 @@ import static com.newrelic.jfr.daemon.EnvironmentVars.JFR_SHARED_FILESYSTEM;
 import static com.newrelic.jfr.daemon.EnvironmentVars.METRICS_INGEST_URI;
 import static com.newrelic.jfr.daemon.EnvironmentVars.REMOTE_JMX_HOST;
 import static com.newrelic.jfr.daemon.EnvironmentVars.REMOTE_JMX_PORT;
-import static com.newrelic.jfr.daemon.JFRUploader.COMMON_ATTRIBUTES;
 import static java.util.function.Function.identity;
-
-import com.newrelic.jfr.ToEventRegistry;
-import com.newrelic.jfr.ToMetricRegistry;
-import com.newrelic.jfr.ToSummaryRegistry;
-import com.newrelic.jfr.daemon.lifecycle.MBeanServerConnector;
-import com.newrelic.jfr.daemon.lifecycle.RemoteEntityGuid;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.util.Optional;
-import java.util.concurrent.LinkedBlockingQueue;
-import javax.management.MBeanServerConnection;
-import jdk.jfr.consumer.RecordedEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JFRDaemon {
   private static final Logger logger = LoggerFactory.getLogger(JFRDaemon.class);
@@ -73,14 +69,8 @@ public class JFRDaemon {
 
   static JFRUploader buildUploader(DaemonConfig config, Optional<String> entityGuid)
       throws MalformedURLException {
-    String hostname = findHostname();
-    var attr =
-        COMMON_ATTRIBUTES
-            .put(APP_NAME, config.getMonitoredAppName())
-            .put(SERVICE_NAME, config.getMonitoredAppName())
-            .put(HOSTNAME, hostname);
-    entityGuid.ifPresent(guid -> attr.put("entity.guid", guid));
 
+    var attr = new JFRCommonAttributes(config).build(entityGuid);
     var eventConverter =
         EventConverter.builder()
             .commonAttributes(attr)
@@ -94,14 +84,4 @@ public class JFRDaemon {
     return new JFRUploader(telemetryClient, recordedEventBuffer, eventConverter);
   }
 
-  private static String findHostname() {
-    try {
-      return InetAddress.getLocalHost().toString();
-    } catch (Throwable e) {
-      var loopback = InetAddress.getLoopbackAddress().toString();
-      logger.error(
-          "Unable to get localhost IP, defaulting to loopback address," + loopback + ".", e);
-      return loopback;
-    }
-  }
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
@@ -7,21 +7,6 @@
 
 package com.newrelic.jfr.daemon;
 
-import com.newrelic.jfr.ToEventRegistry;
-import com.newrelic.jfr.ToMetricRegistry;
-import com.newrelic.jfr.ToSummaryRegistry;
-import com.newrelic.jfr.daemon.lifecycle.MBeanServerConnector;
-import com.newrelic.jfr.daemon.lifecycle.RemoteEntityGuid;
-import jdk.jfr.consumer.RecordedEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.management.MBeanServerConnection;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.util.Optional;
-import java.util.concurrent.LinkedBlockingQueue;
-
 import static com.newrelic.jfr.daemon.EnvironmentVars.ENV_APP_NAME;
 import static com.newrelic.jfr.daemon.EnvironmentVars.EVENTS_INGEST_URI;
 import static com.newrelic.jfr.daemon.EnvironmentVars.INSERT_API_KEY;
@@ -30,6 +15,20 @@ import static com.newrelic.jfr.daemon.EnvironmentVars.METRICS_INGEST_URI;
 import static com.newrelic.jfr.daemon.EnvironmentVars.REMOTE_JMX_HOST;
 import static com.newrelic.jfr.daemon.EnvironmentVars.REMOTE_JMX_PORT;
 import static java.util.function.Function.identity;
+
+import com.newrelic.jfr.ToEventRegistry;
+import com.newrelic.jfr.ToMetricRegistry;
+import com.newrelic.jfr.ToSummaryRegistry;
+import com.newrelic.jfr.daemon.lifecycle.MBeanServerConnector;
+import com.newrelic.jfr.daemon.lifecycle.RemoteEntityGuid;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+import javax.management.MBeanServerConnection;
+import jdk.jfr.consumer.RecordedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JFRDaemon {
   private static final Logger logger = LoggerFactory.getLogger(JFRDaemon.class);
@@ -83,5 +82,4 @@ public class JFRDaemon {
     var recordedEventBuffer = new RecordedEventBuffer(queue);
     return new JFRUploader(telemetryClient, recordedEventBuffer, eventConverter);
   }
-
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
@@ -31,11 +31,6 @@ public final class JFRUploader {
           throw new RuntimeException("Error opening recording file", e);
         }
       };
-  static final Attributes COMMON_ATTRIBUTES =
-      new Attributes()
-          .put(INSTRUMENTATION_NAME, "JFR")
-          .put(INSTRUMENTATION_PROVIDER, "JFR-Uploader")
-          .put(COLLECTOR_NAME, "JFR-Uploader");
 
   private final TelemetryClient telemetryClient;
   private final RecordedEventBuffer recordedEventBuffer;

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
@@ -9,7 +9,6 @@ package com.newrelic.jfr.daemon;
 
 import static com.newrelic.jfr.daemon.AttributeNames.*;
 
-import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.TelemetryClient;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRCommonAttributesTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRCommonAttributesTest.java
@@ -1,0 +1,103 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.jfr.daemon;
+
+import com.newrelic.telemetry.Attributes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.UnknownHostException;
+import java.util.Optional;
+
+import static com.newrelic.jfr.daemon.AttributeNames.APP_NAME;
+import static com.newrelic.jfr.daemon.AttributeNames.HOSTNAME;
+import static com.newrelic.jfr.daemon.AttributeNames.SERVICE_NAME;
+import static com.newrelic.jfr.daemon.JFRCommonAttributes.COMMON_ATTRIBUTES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JFRCommonAttributesTest {
+
+    JFRCommonAttributes.HostInfo hostInfo;
+    private DaemonConfig config;
+
+    @BeforeEach
+    void setup() {
+        hostInfo = new JFRCommonAttributes.HostInfo() {
+            @Override
+            public String getLoopback() {
+                return "127.0.0.1";
+            }
+
+            @Override
+            public String getHost() {
+                return "example.com";
+            }
+        };
+        config = DaemonConfig.builder()
+                .monitoredAppName("myApp")
+                .apiKey("sekret")
+                .build();
+    }
+
+    @Test
+    void testBuildWithEntityGuid() {
+        var entityGuid = Optional.of("90210");
+
+        var testClass = new JFRCommonAttributes(config, hostInfo);
+
+        var expected = new Attributes(COMMON_ATTRIBUTES)
+                .put(APP_NAME, config.getMonitoredAppName())
+                .put(SERVICE_NAME, config.getMonitoredAppName())
+                .put(HOSTNAME, "example.com")
+                .put("entity.guid", entityGuid.get());
+
+        var result = testClass.build(entityGuid);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testBuildWithNoEntityGuid() {
+        var testClass = new JFRCommonAttributes(config, hostInfo);
+
+        var expected = new Attributes(COMMON_ATTRIBUTES)
+                .put(APP_NAME, config.getMonitoredAppName())
+                .put(SERVICE_NAME, config.getMonitoredAppName())
+                .put(HOSTNAME, "example.com");
+
+        var result = testClass.build(Optional.empty());
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testHostnameLookupFails() {
+        var entityGuid = Optional.of("90210");
+        var hostInfo = new JFRCommonAttributes.HostInfo() {
+            @Override
+            public String getHost() throws UnknownHostException {
+                throw new UnknownHostException("What is that?");
+            }
+
+            @Override
+            public String getLoopback() {
+                return "froot";
+            }
+        };
+
+        var testClass = new JFRCommonAttributes(config, hostInfo);
+
+        var expected = new Attributes(COMMON_ATTRIBUTES)
+                .put(APP_NAME, config.getMonitoredAppName())
+                .put(SERVICE_NAME, config.getMonitoredAppName())
+                .put(HOSTNAME, "froot")
+                .put("entity.guid", entityGuid.get());
+
+        var result = testClass.build(entityGuid);
+        assertEquals(expected, result);
+    }
+
+}

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRCommonAttributesTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRCommonAttributesTest.java
@@ -7,96 +7,96 @@
 
 package com.newrelic.jfr.daemon;
 
-import com.newrelic.telemetry.Attributes;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.net.UnknownHostException;
-import java.util.Optional;
-
 import static com.newrelic.jfr.daemon.AttributeNames.APP_NAME;
 import static com.newrelic.jfr.daemon.AttributeNames.HOSTNAME;
 import static com.newrelic.jfr.daemon.AttributeNames.SERVICE_NAME;
 import static com.newrelic.jfr.daemon.JFRCommonAttributes.COMMON_ATTRIBUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.newrelic.telemetry.Attributes;
+import java.net.UnknownHostException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 class JFRCommonAttributesTest {
 
-    JFRCommonAttributes.HostInfo hostInfo;
-    private DaemonConfig config;
+  JFRCommonAttributes.HostInfo hostInfo;
+  private DaemonConfig config;
 
-    @BeforeEach
-    void setup() {
-        hostInfo = new JFRCommonAttributes.HostInfo() {
-            @Override
-            public String getLoopback() {
-                return "127.0.0.1";
-            }
+  @BeforeEach
+  void setup() {
+    hostInfo =
+        new JFRCommonAttributes.HostInfo() {
+          @Override
+          public String getLoopback() {
+            return "127.0.0.1";
+          }
 
-            @Override
-            public String getHost() {
-                return "example.com";
-            }
+          @Override
+          public String getHost() {
+            return "example.com";
+          }
         };
-        config = DaemonConfig.builder()
-                .monitoredAppName("myApp")
-                .apiKey("sekret")
-                .build();
-    }
+    config = DaemonConfig.builder().monitoredAppName("myApp").apiKey("sekret").build();
+  }
 
-    @Test
-    void testBuildWithEntityGuid() {
-        var entityGuid = Optional.of("90210");
+  @Test
+  void testBuildWithEntityGuid() {
+    var entityGuid = Optional.of("90210");
 
-        var testClass = new JFRCommonAttributes(config, hostInfo);
+    var testClass = new JFRCommonAttributes(config, hostInfo);
 
-        var expected = new Attributes(COMMON_ATTRIBUTES)
-                .put(SERVICE_NAME, config.getMonitoredAppName())
-                .put(HOSTNAME, "example.com")
-                .put("entity.guid", entityGuid.get());
+    var expected =
+        new Attributes(COMMON_ATTRIBUTES)
+            .put(SERVICE_NAME, config.getMonitoredAppName())
+            .put(HOSTNAME, "example.com")
+            .put("entity.guid", entityGuid.get());
 
-        var result = testClass.build(entityGuid);
-        assertEquals(expected, result);
-    }
+    var result = testClass.build(entityGuid);
+    assertEquals(expected, result);
+  }
 
-    @Test
-    void testBuildWithNoEntityGuid() {
-        var testClass = new JFRCommonAttributes(config, hostInfo);
+  @Test
+  void testBuildWithNoEntityGuid() {
+    var testClass = new JFRCommonAttributes(config, hostInfo);
 
-        var expected = new Attributes(COMMON_ATTRIBUTES)
-                .put(APP_NAME, config.getMonitoredAppName())
-                .put(SERVICE_NAME, config.getMonitoredAppName())
-                .put(HOSTNAME, "example.com");
+    var expected =
+        new Attributes(COMMON_ATTRIBUTES)
+            .put(APP_NAME, config.getMonitoredAppName())
+            .put(SERVICE_NAME, config.getMonitoredAppName())
+            .put(HOSTNAME, "example.com");
 
-        var result = testClass.build(Optional.empty());
-        assertEquals(expected, result);
-    }
+    var result = testClass.build(Optional.empty());
+    assertEquals(expected, result);
+  }
 
-    @Test
-    void testHostnameLookupFails() {
-        var entityGuid = Optional.of("90210");
-        var hostInfo = new JFRCommonAttributes.HostInfo() {
-            @Override
-            public String getHost() throws UnknownHostException {
-                throw new UnknownHostException("What is that?");
-            }
+  @Test
+  void testHostnameLookupFails() {
+    var entityGuid = Optional.of("90210");
+    var hostInfo =
+        new JFRCommonAttributes.HostInfo() {
+          @Override
+          public String getHost() throws UnknownHostException {
+            throw new UnknownHostException("What is that?");
+          }
 
-            @Override
-            public String getLoopback() {
-                return "froot";
-            }
+          @Override
+          public String getLoopback() {
+            return "froot";
+          }
         };
 
-        var testClass = new JFRCommonAttributes(config, hostInfo);
+    var testClass = new JFRCommonAttributes(config, hostInfo);
 
-        var expected = new Attributes(COMMON_ATTRIBUTES)
-                .put(APP_NAME, config.getMonitoredAppName())
-                .put(SERVICE_NAME, config.getMonitoredAppName())
-                .put(HOSTNAME, "froot")
-                .put("entity.guid", entityGuid.get());
+    var expected =
+        new Attributes(COMMON_ATTRIBUTES)
+            .put(APP_NAME, config.getMonitoredAppName())
+            .put(SERVICE_NAME, config.getMonitoredAppName())
+            .put(HOSTNAME, "froot")
+            .put("entity.guid", entityGuid.get());
 
-        var result = testClass.build(entityGuid);
-        assertEquals(expected, result);
-    }
-
+    var result = testClass.build(entityGuid);
+    assertEquals(expected, result);
+  }
 }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRCommonAttributesTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRCommonAttributesTest.java
@@ -51,7 +51,6 @@ class JFRCommonAttributesTest {
         var testClass = new JFRCommonAttributes(config, hostInfo);
 
         var expected = new Attributes(COMMON_ATTRIBUTES)
-                .put(APP_NAME, config.getMonitoredAppName())
                 .put(SERVICE_NAME, config.getMonitoredAppName())
                 .put(HOSTNAME, "example.com")
                 .put("entity.guid", entityGuid.get());


### PR DESCRIPTION
This resolves #60 

We only set the `app.name` common attr now if the entity guid is missing.  When it is present, it will be stitched up by the backend platform.