### PR TITLE
Gate on readiness check for entity guid

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.management.MBeanServerConnection;
 import jdk.jfr.consumer.RecordedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +36,7 @@ public class JFRDaemon {
   public static void main(String[] args) {
     try {
       var config = buildConfig();
-      var mBeanServerConnection =
-          new MBeanServerConnector(config).getConnection();
+      var mBeanServerConnection = new MBeanServerConnector(config).getConnection();
       var readinessCheck = new AtomicBoolean(false);
 
       var entityGuid = new RemoteEntityGuid(mBeanServerConnection).queryFromJmx();
@@ -71,7 +69,8 @@ public class JFRDaemon {
     return builder.build();
   }
 
-  static JFRUploader buildUploader(DaemonConfig config, Optional<String> entityGuid, AtomicBoolean readinessCheck)
+  static JFRUploader buildUploader(
+      DaemonConfig config, Optional<String> entityGuid, AtomicBoolean readinessCheck)
       throws MalformedURLException {
 
     var attr = new JFRCommonAttributes(config).build(entityGuid);
@@ -80,11 +79,11 @@ public class JFRDaemon {
     var queue = new LinkedBlockingQueue<RecordedEvent>(50000);
     var recordedEventBuffer = new RecordedEventBuffer(queue);
     return JFRUploader.builder()
-            .telemetryClient(telemetryClient)
-            .recordedEventBuffer(recordedEventBuffer)
-            .eventConverter(eventConverter)
-            .readinessCheck(readinessCheck)
-            .build();
+        .telemetryClient(telemetryClient)
+        .recordedEventBuffer(recordedEventBuffer)
+        .eventConverter(eventConverter)
+        .readinessCheck(readinessCheck)
+        .build();
   }
 
   private static EventConverter buildEventConverter(com.newrelic.telemetry.Attributes attr) {

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
@@ -25,6 +25,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.management.MBeanServerConnection;
 import jdk.jfr.consumer.RecordedEvent;
 import org.slf4j.Logger;
@@ -35,11 +36,15 @@ public class JFRDaemon {
 
   public static void main(String[] args) {
     try {
-      DaemonConfig config = buildConfig();
-      MBeanServerConnection mBeanServerConnection =
+      var config = buildConfig();
+      var mBeanServerConnection =
           new MBeanServerConnector(config).getConnection();
-      Optional<String> entityGuid = new RemoteEntityGuid(mBeanServerConnection).queryFromJmx();
-      var uploader = buildUploader(config, entityGuid);
+      var readinessCheck = new AtomicBoolean(false);
+
+      var entityGuid = new RemoteEntityGuid(mBeanServerConnection).queryFromJmx();
+      readinessCheck.set(true);
+
+      var uploader = buildUploader(config, entityGuid, readinessCheck);
       var jfrController = new JFRController(uploader, config);
       jfrController.setup();
       jfrController.loop(config.getHarvestInterval());
@@ -66,20 +71,28 @@ public class JFRDaemon {
     return builder.build();
   }
 
-  static JFRUploader buildUploader(DaemonConfig config, Optional<String> entityGuid)
+  static JFRUploader buildUploader(DaemonConfig config, Optional<String> entityGuid, AtomicBoolean readinessCheck)
       throws MalformedURLException {
 
     var attr = new JFRCommonAttributes(config).build(entityGuid);
-    var eventConverter =
-        EventConverter.builder()
-            .commonAttributes(attr)
-            .metricMappers(ToMetricRegistry.createDefault())
-            .eventMapper(ToEventRegistry.createDefault())
-            .summaryMappers(ToSummaryRegistry.createDefault())
-            .build();
+    var eventConverter = buildEventConverter(attr);
     var telemetryClient = new TelemetryClientFactory().build(config);
     var queue = new LinkedBlockingQueue<RecordedEvent>(50000);
     var recordedEventBuffer = new RecordedEventBuffer(queue);
-    return new JFRUploader(telemetryClient, recordedEventBuffer, eventConverter);
+    return JFRUploader.builder()
+            .telemetryClient(telemetryClient)
+            .recordedEventBuffer(recordedEventBuffer)
+            .eventConverter(eventConverter)
+            .readinessCheck(readinessCheck)
+            .build();
+  }
+
+  private static EventConverter buildEventConverter(com.newrelic.telemetry.Attributes attr) {
+    return EventConverter.builder()
+        .commonAttributes(attr)
+        .metricMappers(ToMetricRegistry.createDefault())
+        .eventMapper(ToEventRegistry.createDefault())
+        .summaryMappers(ToSummaryRegistry.createDefault())
+        .build();
   }
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import jdk.jfr.consumer.RecordingFile;
@@ -40,7 +39,7 @@ public final class JFRUploader {
   private final Consumer<Path> fileDeleter;
   private final AtomicBoolean readinessCheck;
 
-  private JFRUploader(Builder builder){
+  private JFRUploader(Builder builder) {
     this.telemetryClient = builder.telemetryClient;
     this.recordedEventBuffer = builder.recordedEventBuffer;
     this.eventConverter = builder.eventConverter;
@@ -69,7 +68,7 @@ public final class JFRUploader {
   }
 
   private void maybeDrainAndSend() {
-    if(!readinessCheck.get()){
+    if (!readinessCheck.get()) {
       logger.warn("Drain attempt skipped -- readiness check not yet ready.");
       return;
     }
@@ -104,10 +103,9 @@ public final class JFRUploader {
     }
   }
 
-  public static Builder builder(){
+  public static Builder builder() {
     return new Builder();
   }
-
 
   public static class Builder {
     private TelemetryClient telemetryClient;
@@ -117,37 +115,37 @@ public final class JFRUploader {
     private Consumer<Path> fileDeleter = JFRUploader::deleteFile;
     private AtomicBoolean readinessCheck;
 
-    public Builder telemetryClient(TelemetryClient telemetryClient){
+    public Builder telemetryClient(TelemetryClient telemetryClient) {
       this.telemetryClient = telemetryClient;
       return this;
     }
 
-    public Builder recordedEventBuffer(RecordedEventBuffer recordedEventBuffer){
+    public Builder recordedEventBuffer(RecordedEventBuffer recordedEventBuffer) {
       this.recordedEventBuffer = recordedEventBuffer;
       return this;
     }
 
-    public Builder eventConverter(EventConverter converter){
+    public Builder eventConverter(EventConverter converter) {
       this.eventConverter = converter;
       return this;
     }
 
-    public Builder recordingFileOpener(Function<Path,RecordingFile> opener){
+    public Builder recordingFileOpener(Function<Path, RecordingFile> opener) {
       this.recordingFileOpener = opener;
       return this;
     }
 
-    public Builder fileDeleter(Consumer<Path> fileDeleter){
+    public Builder fileDeleter(Consumer<Path> fileDeleter) {
       this.fileDeleter = fileDeleter;
       return this;
     }
 
-    public Builder readinessCheck(AtomicBoolean readinessCheck){
+    public Builder readinessCheck(AtomicBoolean readinessCheck) {
       this.readinessCheck = readinessCheck;
       return this;
     }
 
-    public JFRUploader build(){
+    public JFRUploader build() {
       return new JFRUploader(this);
     }
   }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
@@ -13,6 +13,8 @@ import com.newrelic.telemetry.TelemetryClient;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import jdk.jfr.consumer.RecordingFile;
@@ -36,30 +38,15 @@ public final class JFRUploader {
   private final EventConverter eventConverter;
   private final Function<Path, RecordingFile> recordingFileOpener;
   private final Consumer<Path> fileDeleter;
+  private final AtomicBoolean readinessCheck;
 
-  public JFRUploader(
-      TelemetryClient telemetryClient,
-      RecordedEventBuffer recordedEventBuffer,
-      EventConverter eventConverter) {
-    this(
-        telemetryClient,
-        recordedEventBuffer,
-        eventConverter,
-        OPEN_RECORDING_FILE,
-        JFRUploader::deleteFile);
-  }
-
-  public JFRUploader(
-      TelemetryClient telemetryClient,
-      RecordedEventBuffer recordedEventBuffer,
-      EventConverter eventConverter,
-      Function<Path, RecordingFile> recordingFileOpener,
-      Consumer<Path> fileDeleter) {
-    this.telemetryClient = telemetryClient;
-    this.recordedEventBuffer = recordedEventBuffer;
-    this.eventConverter = eventConverter;
-    this.recordingFileOpener = recordingFileOpener;
-    this.fileDeleter = fileDeleter;
+  private JFRUploader(Builder builder){
+    this.telemetryClient = builder.telemetryClient;
+    this.recordedEventBuffer = builder.recordedEventBuffer;
+    this.eventConverter = builder.eventConverter;
+    this.recordingFileOpener = builder.recordingFileOpener;
+    this.fileDeleter = builder.fileDeleter;
+    this.readinessCheck = builder.readinessCheck;
   }
 
   void handleFile(final Path dumpFile) {
@@ -82,6 +69,10 @@ public final class JFRUploader {
   }
 
   private void maybeDrainAndSend() {
+    if(!readinessCheck.get()){
+      logger.warn("Drain attempt skipped -- readiness check not yet ready.");
+      return;
+    }
     BufferedTelemetry telemetry = eventConverter.convert(recordedEventBuffer);
     sendMetrics(telemetry);
     sendEvents(telemetry);
@@ -110,6 +101,54 @@ public final class JFRUploader {
       // TODO: I think we actually want to log an error here and exit cleanly, rather than
       // throw an exception on the executor thread
       throw new RuntimeException(e);
+    }
+  }
+
+  public static Builder builder(){
+    return new Builder();
+  }
+
+
+  public static class Builder {
+    private TelemetryClient telemetryClient;
+    private RecordedEventBuffer recordedEventBuffer;
+    private EventConverter eventConverter;
+    private Function<Path, RecordingFile> recordingFileOpener = OPEN_RECORDING_FILE;
+    private Consumer<Path> fileDeleter = JFRUploader::deleteFile;
+    private AtomicBoolean readinessCheck;
+
+    public Builder telemetryClient(TelemetryClient telemetryClient){
+      this.telemetryClient = telemetryClient;
+      return this;
+    }
+
+    public Builder recordedEventBuffer(RecordedEventBuffer recordedEventBuffer){
+      this.recordedEventBuffer = recordedEventBuffer;
+      return this;
+    }
+
+    public Builder eventConverter(EventConverter converter){
+      this.eventConverter = converter;
+      return this;
+    }
+
+    public Builder recordingFileOpener(Function<Path,RecordingFile> opener){
+      this.recordingFileOpener = opener;
+      return this;
+    }
+
+    public Builder fileDeleter(Consumer<Path> fileDeleter){
+      this.fileDeleter = fileDeleter;
+      return this;
+    }
+
+    public Builder readinessCheck(AtomicBoolean readinessCheck){
+      this.readinessCheck = readinessCheck;
+      return this;
+    }
+
+    public JFRUploader build(){
+      return new JFRUploader(this);
     }
   }
 }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRUploaderTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRUploaderTest.java
@@ -109,13 +109,14 @@ class JFRUploaderTest {
 
   private JFRUploader buildTestClass(boolean ready) {
     var testClass =
-            JFRUploader.builder().telemetryClient(telemetryClient)
-                    .recordedEventBuffer(recordedEventBuffer)
-                    .eventConverter(eventConverter)
-                    .recordingFileOpener(x -> recordingFile)
-                    .fileDeleter(deleter)
-                    .readinessCheck(new AtomicBoolean(ready))
-                    .build();
+        JFRUploader.builder()
+            .telemetryClient(telemetryClient)
+            .recordedEventBuffer(recordedEventBuffer)
+            .eventConverter(eventConverter)
+            .recordingFileOpener(x -> recordingFile)
+            .fileDeleter(deleter)
+            .readinessCheck(new AtomicBoolean(ready))
+            .build();
     return testClass;
   }
 
@@ -124,12 +125,13 @@ class JFRUploaderTest {
     doThrow(new RuntimeException("kaboom!")).when(eventConverter).convert(recordedEventBuffer);
 
     var testClass =
-            JFRUploader.builder().telemetryClient(telemetryClient)
-                    .recordedEventBuffer(recordedEventBuffer)
-                    .eventConverter(eventConverter)
-                    .recordingFileOpener(x -> recordingFile)
-                    .fileDeleter(deleter)
-                    .build();
+        JFRUploader.builder()
+            .telemetryClient(telemetryClient)
+            .recordedEventBuffer(recordedEventBuffer)
+            .eventConverter(eventConverter)
+            .recordingFileOpener(x -> recordingFile)
+            .fileDeleter(deleter)
+            .build();
 
     testClass.handleFile(filePath);
     // no exception, and since we can't convert don't try sending

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRUploaderTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRUploaderTest.java
@@ -120,12 +120,12 @@ class JFRUploaderTest {
 
   private JFRUploader buildTestClass(boolean ready) {
     return JFRUploader.builder()
-            .telemetryClient(telemetryClient)
-            .recordedEventBuffer(recordedEventBuffer)
-            .eventConverter(eventConverter)
-            .recordingFileOpener(x -> recordingFile)
-            .fileDeleter(deleter)
-            .readinessCheck(new AtomicBoolean(ready))
-            .build();
+        .telemetryClient(telemetryClient)
+        .recordedEventBuffer(recordedEventBuffer)
+        .eventConverter(eventConverter)
+        .recordingFileOpener(x -> recordingFile)
+        .fileDeleter(deleter)
+        .readinessCheck(new AtomicBoolean(ready))
+        .build();
   }
 }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRUploaderTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/JFRUploaderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -57,9 +58,7 @@ class JFRUploaderTest {
   @Disabled
   void testUploads() {
 
-    var testClass =
-        new JFRUploader(
-            telemetryClient, recordedEventBuffer, eventConverter, x -> recordingFile, deleter);
+    JFRUploader testClass = buildTestClass();
 
     testClass.handleFile(filePath);
 
@@ -76,9 +75,7 @@ class JFRUploaderTest {
           deleterCalled.set(true);
           throw new RuntimeException("KABOOM!");
         };
-    var testClass =
-        new JFRUploader(
-            telemetryClient, recordedEventBuffer, eventConverter, x -> recordingFile, deleter);
+    JFRUploader testClass = buildTestClass();
 
     assertThrows(RuntimeException.class, () -> testClass.handleFile(filePath));
     assertTrue(deleterCalled.get());
@@ -90,9 +87,7 @@ class JFRUploaderTest {
         .when(recordedEventBuffer)
         .bufferEvents(filePath, recordingFile);
 
-    var testClass =
-        new JFRUploader(
-            telemetryClient, recordedEventBuffer, eventConverter, x -> recordingFile, deleter);
+    JFRUploader testClass = buildTestClass();
 
     testClass.handleFile(filePath);
     // no exception, but we still try and send
@@ -101,12 +96,40 @@ class JFRUploaderTest {
   }
 
   @Test
+  void testSkipsIfNotReady() {
+    JFRUploader testClass = buildTestClass(false);
+    testClass.handleFile(filePath);
+    verifyNoInteractions(eventConverter);
+    verifyNoInteractions(telemetryClient);
+  }
+
+  private JFRUploader buildTestClass() {
+    return buildTestClass(true);
+  }
+
+  private JFRUploader buildTestClass(boolean ready) {
+    var testClass =
+            JFRUploader.builder().telemetryClient(telemetryClient)
+                    .recordedEventBuffer(recordedEventBuffer)
+                    .eventConverter(eventConverter)
+                    .recordingFileOpener(x -> recordingFile)
+                    .fileDeleter(deleter)
+                    .readinessCheck(new AtomicBoolean(ready))
+                    .build();
+    return testClass;
+  }
+
+  @Test
   public void testConvertThrowsExceptionIsHandled() throws Exception {
     doThrow(new RuntimeException("kaboom!")).when(eventConverter).convert(recordedEventBuffer);
 
     var testClass =
-        new JFRUploader(
-            telemetryClient, recordedEventBuffer, eventConverter, x -> recordingFile, deleter);
+            JFRUploader.builder().telemetryClient(telemetryClient)
+                    .recordedEventBuffer(recordedEventBuffer)
+                    .eventConverter(eventConverter)
+                    .recordingFileOpener(x -> recordingFile)
+                    .fileDeleter(deleter)
+                    .build();
 
     testClass.handleFile(filePath);
     // no exception, and since we can't convert don't try sending


### PR DESCRIPTION
This resolves #73 .

It reads a little silly because the entity guid fetching is blocking/synchronous...but it sets the stage for the next change, which will cause the entity guid fetching to be done on its own background thread.  After that, this will make more sense.

Note: This is built on top of #74 and will need a rebase (so probably don't bother reviewing until that one is merged)