### PR TITLE
Standardize release process

### DIFF
--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -1,4 +1,4 @@
-name: main build
+name: main build publishes a snapshot
 
 on:
   push:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,27 @@
+name: publish release version explicitly
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: 11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      env:
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+      run: ./gradlew build publish -Prelease=true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+This file documents noteworthy changes to the `jfr-core` projects.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Coming soon
+* If the agent is present, no longer wait for the agent to connect to obtain an entity guid.
+Instead, buffer the data and wait to send it until the entity guid is available.
+* Omit the app name from the common attributes when the entity guid is present
+
+## Version 0.3.0 (2020-07-31)
+
+* JFR Daemon - change main class from `JFRController` to `JFRDaemon`
+* JFR Daemon - now supports fetching `entity.guid` common attribute from remote MBean
+* JRR Daemon - startup delays until service startup is complete
+* JFR Daemon - make determining localhost address more robust
+* JFR Daemon - retry with backoff when recordings fail
+* JFR Mappers - null guard against null thread in `ThreadAllocationStatistics` events
+* JFR Mappers - fix stack overflow boundary case when truncating stack frames

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,11 @@ allprojects {
     }
 }
 
+// -Prelease=true will render a non-snapshot version
+// All other values (including unset) will render a snapshot version.
+val release: String? by project
+version = if("true" == release) "${version}" else "${version}-SNAPSHOT"
+
 object Versions {
     const val junit = "5.6.2"
     const val mockitoJunit = "3.3.3"
@@ -54,7 +59,8 @@ subprojects {
             maven {
                 val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
                 val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-                url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+
+                url = if("true" == release) releasesRepoUrl else snapshotsRepoUrl
                 credentials {
                     username = System.getenv("SONATYPE_USERNAME")
                     password = System.getenv("SONATYPE_PASSWORD")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.4.0-SNAPSHOT
+version=0.4.0


### PR DESCRIPTION
I think that we prefer to initiate releases with a github release, so let's adopt that here for this repo.
I also added a changelog.