### PR TITLE
Improve queue handling

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
@@ -86,7 +86,7 @@ public class JFRDaemon {
       AtomicReference<EventConverter> eventConverterReference)
       throws MalformedURLException {
     var telemetryClient = new TelemetryClientFactory().build(config);
-    var queue = new LinkedBlockingQueue<RecordedEvent>(50000);
+    var queue = new LinkedBlockingQueue<RecordedEvent>(250_000);
     var recordedEventBuffer = new RecordedEventBuffer(queue);
     return JFRUploader.builder()
         .telemetryClient(telemetryClient)

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/RecordedEventBuffer.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/RecordedEventBuffer.java
@@ -38,7 +38,7 @@ public class RecordedEventBuffer {
     logger.debug("Looking in " + dumpFile + " for events after: " + ctx.getLastSeen());
     while (file.hasMoreEvents()) {
       var event = file.readEvent();
-      if(!handleEvent(event)){
+      if (!handleEvent(event)) {
         logger.warn("Ignoring remaining events in this file due to full queue!");
         break;
       }
@@ -64,11 +64,11 @@ public class RecordedEventBuffer {
   }
 
   private boolean enqueue(RecordedEvent event) {
-      boolean success = queue.offer(event);
-      if(!success) {
-        logger.error("Rejecting RecordedEvent -- queue is full!!!");
-      }
-      return success;
+    boolean success = queue.offer(event);
+    if (!success) {
+      logger.error("Rejecting RecordedEvent -- queue is full!!!");
+    }
+    return success;
   }
 
   public Stream<RecordedEvent> drainToStream() {

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/RecordedEventBufferTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/RecordedEventBufferTest.java
@@ -8,6 +8,8 @@ package com.newrelic.jfr.daemon;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -68,6 +70,29 @@ class RecordedEventBufferTest {
     var result = testClass.drainToStream().collect(Collectors.toList());
     assertEquals(List.of(e11, e12, e22), result);
     assertEquals(0, queue.size());
+  }
+
+  @Test
+  public void testQueueGetsFilledUp() throws Exception {
+    var queue = new ArrayBlockingQueue<RecordedEvent>(2);
+    var dumpPath = new File("/tmp/file.jfr").toPath();
+
+    var e1 = makeEvent(666);
+    var e2 = makeEvent(667);
+    var e3 = makeEvent(668);
+    var recordingFile = mock(RecordingFile.class);
+
+    when(recordingFile.hasMoreEvents()).thenReturn(true);
+    when(recordingFile.readEvent()).thenReturn(e1, e2, e3);
+
+    var testClass = new RecordedEventBuffer(queue);
+    testClass.bufferEvents(dumpPath, recordingFile);
+    assertEquals(2, queue.size());
+    var result = testClass.drainToStream().collect(Collectors.toList());
+    verify(recordingFile, times(3)).readEvent();
+    // read 3 times, but only 1 and 2 made it in, even thought we always say we have more events
+    assertEquals(List.of(e1, e2), result);
+
   }
 
   private RecordedEvent makeEvent(long ms) {

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/RecordedEventBufferTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/RecordedEventBufferTest.java
@@ -92,7 +92,6 @@ class RecordedEventBufferTest {
     verify(recordingFile, times(3)).readEvent();
     // read 3 times, but only 1 and 2 made it in, even thought we always say we have more events
     assertEquals(List.of(e1, e2), result);
-
   }
 
   private RecordedEvent makeEvent(long ms) {


### PR DESCRIPTION
While troubleshooting a separate issue, it was discovered that the writing of the `Queue<RecordedEvent>` happens on the same thread that reads from that queue (to drain it).  As a result, in the event that a file had a very large number of events (> 50,000), the queue would be full and the `.put()` would cause that thread to block and never recover (because no other threads read from the queue).  

The fix here is to increase the default max queue size to 250k (5x increase) and use `.offer()` instead of `.put()`.  If the offer fails, we log a warning, break out of the file loop, and drop all the remaining events from this file.  The queue will then be drained, and we will pick back up with the next file 10 seconds later.