### PR TITLE
rename events and metrics

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JITCompilationMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JITCompilationMapper.java
@@ -40,7 +40,7 @@ public class JITCompilationMapper implements EventToEvent {
     attr.put("duration", duration.toMillis());
     attr.put("succeeded", Workarounds.getSucceeded(event));
 
-    return List.of(new Event("jfr:Compilation", attr, timestamp));
+    return List.of(new Event("JfrCompilation", attr, timestamp));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMInformationMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMInformationMapper.java
@@ -43,6 +43,6 @@ public class JVMInformationMapper implements EventToEvent {
     attr.put("jvmStartTime", event.getInstant("jvmStartTime").toEpochMilli());
     attr.put("jvmVersion", event.getString("jvmVersion"));
 
-    return List.of(new Event("jfr:JVMInformation", attr, timestamp));
+    return List.of(new Event("JfrJVMInformation", attr, timestamp));
   }
 }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapper.java
@@ -33,6 +33,6 @@ public class JVMSystemPropertyMapper implements EventToEvent {
     attr.put("jvmProperty", event.getString("key"));
     attr.put("jvmPropertyValue", event.getString("value"));
 
-    return List.of(new Event("jfr:JVMInformation", attr, timestamp));
+    return List.of(new Event("JfrJVMInformation", attr, timestamp));
   }
 }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/MethodSampleMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/MethodSampleMapper.java
@@ -59,7 +59,7 @@ public class MethodSampleMapper implements EventToEvent {
     attr.put("thread.state", ev.getString("state"));
     attr.put("stackTrace", MethodSupport.serialize(ev.getStackTrace()));
 
-    return List.of(new Event("jfr:MethodSample", attr, timestamp));
+    return List.of(new Event("JfrMethodSample", attr, timestamp));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/ThreadLockEventMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/ThreadLockEventMapper.java
@@ -29,7 +29,7 @@ public class ThreadLockEventMapper implements EventToEvent {
       attr.put("class", ev.getClass("monitorClass").getName());
       attr.put("duration", duration.toMillis());
 
-      return List.of(new Event("jfr:JavaMonitorWait", attr, timestamp));
+      return List.of(new Event("JfrJavaMonitorWait", attr, timestamp));
     }
     return List.of();
   }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/AllocationRequiringGCMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/AllocationRequiringGCMapper.java
@@ -24,7 +24,7 @@ public class AllocationRequiringGCMapper implements EventToMetric {
     var threadName = Workarounds.getThreadName(ev);
     threadName.ifPresent(thread -> attr.put("thread.name", thread));
     return List.of(
-        new Gauge("jfr:AllocationRequiringGC.allocationSize", ev.getLong("size"), timestamp, attr));
+        new Gauge("jfr.AllocationRequiringGC.allocationSize", ev.getLong("size"), timestamp, attr));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/CPUThreadLoadMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/CPUThreadLoadMapper.java
@@ -37,8 +37,8 @@ public class CPUThreadLoadMapper implements EventToMetric {
 
       // Do we need to throttle these events somehow? Or just send everything?
       return List.of(
-          new Gauge("jfr:ThreadCPULoad.user", ev.getDouble("user"), timestamp, attr),
-          new Gauge("jfr:ThreadCPULoad.system", ev.getDouble("system"), timestamp, attr));
+          new Gauge("jfr.ThreadCPULoad.user", ev.getDouble("user"), timestamp, attr),
+          new Gauge("jfr.ThreadCPULoad.system", ev.getDouble("system"), timestamp, attr));
     }
     return List.of();
   }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/ContextSwitchRateMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/ContextSwitchRateMapper.java
@@ -25,7 +25,7 @@ public class ContextSwitchRateMapper implements EventToMetric {
     var timestamp = ev.getStartTime().toEpochMilli();
     var attr = new Attributes();
     return List.of(
-        new Gauge("jfr:ThreadContextSwitchRate", ev.getDouble("switchRate"), timestamp, attr));
+        new Gauge("jfr.ThreadContextSwitchRate", ev.getDouble("switchRate"), timestamp, attr));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/GCHeapSummaryMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/GCHeapSummaryMapper.java
@@ -33,9 +33,9 @@ public class GCHeapSummaryMapper implements EventToMetric {
             .put("reservedEnd", heapSpace.getLong("reservedEnd"));
 
     return List.of(
-        new Gauge("jfr:GCHeapSummary.heapUsed", heapUsed, timestamp, attr),
-        new Gauge("jfr:GCHeapSummary.heapCommittedSize", committedSize, timestamp, attr),
-        new Gauge("jfr:GCHeapSummary.reservedSize", reservedSize, timestamp, attr));
+        new Gauge("jfr.GCHeapSummary.heapUsed", heapUsed, timestamp, attr),
+        new Gauge("jfr.GCHeapSummary.heapCommittedSize", committedSize, timestamp, attr),
+        new Gauge("jfr.GCHeapSummary.reservedSize", reservedSize, timestamp, attr));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/GarbageCollectionMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/GarbageCollectionMapper.java
@@ -24,7 +24,7 @@ public class GarbageCollectionMapper implements EventToMetric {
     var attr =
         new Attributes().put("name", ev.getString("name")).put("cause", ev.getString("cause"));
 
-    return List.of(new Gauge("jfr:GarbageCollection.longestPause", longestPause, timestamp, attr));
+    return List.of(new Gauge("jfr.GarbageCollection.longestPause", longestPause, timestamp, attr));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/MetaspaceSummaryMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/MetaspaceSummaryMapper.java
@@ -17,7 +17,7 @@ import jdk.jfr.consumer.RecordedObject;
 
 public class MetaspaceSummaryMapper implements EventToMetric {
   public static final String EVENT_NAME = "jdk.MetaspaceSummary";
-  static final String NR_METRIC_PREFIX = "jfr:MetaspaceSummary.";
+  static final String NR_METRIC_PREFIX = "jfr.MetaspaceSummary.";
   static final String METASPACE_KEY = "metaspace";
   static final String DATA_SPACE_KEY = "dataSpace";
   static final String CLASS_SPACE_KEY = "classSpace";

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/OverallCPULoadMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/OverallCPULoadMapper.java
@@ -25,9 +25,9 @@ public class OverallCPULoadMapper implements EventToMetric {
     var timestamp = ev.getStartTime().toEpochMilli();
     var attr = new Attributes();
     return List.of(
-        new Gauge("jfr:CPULoad.jvmUser", ev.getDouble("jvmUser"), timestamp, attr),
-        new Gauge("jfr:CPULoad.jvmSystem", ev.getDouble("jvmSystem"), timestamp, attr),
-        new Gauge("jfr:CPULoad.machineTotal", ev.getDouble("machineTotal"), timestamp, attr));
+        new Gauge("jfr.CPULoad.jvmUser", ev.getDouble("jvmUser"), timestamp, attr),
+        new Gauge("jfr.CPULoad.jvmSystem", ev.getDouble("jvmSystem"), timestamp, attr),
+        new Gauge("jfr.CPULoad.machineTotal", ev.getDouble("machineTotal"), timestamp, attr));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapper.java
@@ -27,7 +27,7 @@ public class ThreadAllocationStatisticsMapper implements EventToMetric {
       attr.put("thread.name", t.getJavaName()).put("thread.osName", t.getOSName());
     }
 
-    return List.of(new Gauge("jfr:ThreadAllocationStatistics.allocated", allocated, time, attr));
+    return List.of(new Gauge("jfr.ThreadAllocationStatistics.allocated", allocated, time, attr));
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/G1GarbageCollectionSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/G1GarbageCollectionSummarizer.java
@@ -55,7 +55,7 @@ public final class G1GarbageCollectionSummarizer implements EventToSummary {
     var attr = new Attributes();
     var out =
         new Summary(
-            "jfr:G1GarbageCollection.duration",
+            "jfr.G1GarbageCollection.duration",
             count,
             summarizer.getDurationMillis(),
             summarizer.getMinDurationMillis(),

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkReadSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkReadSummarizer.java
@@ -44,7 +44,7 @@ public class PerThreadNetworkReadSummarizer implements EventToSummary {
     var attr = new Attributes().put("thread.name", threadName);
     var outRead =
         new Summary(
-            "jfr:SocketRead.bytesRead",
+            "jfr.SocketRead.bytesRead",
             bytesSummary.getCount(),
             bytesSummary.getSum(),
             bytesSummary.getMin(),
@@ -54,7 +54,7 @@ public class PerThreadNetworkReadSummarizer implements EventToSummary {
             attr);
     var outDuration =
         new Summary(
-            "jfr:SocketRead.duration",
+            "jfr.SocketRead.duration",
             bytesSummary.getCount(),
             duration.getDurationMillis(),
             duration.getMinDurationMillis(),

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkWriteSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkWriteSummarizer.java
@@ -44,7 +44,7 @@ public class PerThreadNetworkWriteSummarizer implements EventToSummary {
     var attr = new Attributes().put("thread.name", threadName);
     var outWritten =
         new Summary(
-            "jfr:SocketWrite.bytesWritten",
+            "jfr.SocketWrite.bytesWritten",
             bytesSummary.getCount(),
             bytesSummary.getSum(),
             bytesSummary.getMin(),
@@ -54,7 +54,7 @@ public class PerThreadNetworkWriteSummarizer implements EventToSummary {
             attr);
     var outDuration =
         new Summary(
-            "jfr:SocketWrite.duration",
+            "jfr.SocketWrite.duration",
             bytesSummary.getCount(),
             duration.getDurationMillis(),
             duration.getMinDurationMillis(),

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizer.java
@@ -50,7 +50,7 @@ public final class PerThreadObjectAllocationInNewTLABSummarizer implements Event
     var attr = new Attributes().put("thread.name", threadName);
     var out =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             summarizer.getCount(),
             summarizer.getSum(),
             summarizer.getMin(),

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizer.java
@@ -50,7 +50,7 @@ public final class PerThreadObjectAllocationOutsideTLABSummarizer implements Eve
     var attr = new Attributes().put("thread.name", threadName);
     var out =
         new Summary(
-            "jfr:ObjectAllocationOutsideTLAB.allocation",
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
             summarizer.getCount(),
             summarizer.getSum(),
             summarizer.getMin(),

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JITCompilationMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JITCompilationMapperTest.java
@@ -29,7 +29,7 @@ class JITCompilationMapperTest {
             .put("duration", duration.toMillis())
             .put("desc", "[missing]")
             .put("succeeded", true);
-    var expectedEvent = new Event("jfr:Compilation", expectedAttrs, startTime.toEpochMilli());
+    var expectedEvent = new Event("JfrCompilation", expectedAttrs, startTime.toEpochMilli());
     var expected = List.of(expectedEvent);
 
     var event = mock(RecordedEvent.class);

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JVMInformationMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JVMInformationMapperTest.java
@@ -26,7 +26,7 @@ class JVMInformationMapperTest {
             .put("jvmStartTime", startTime.toEpochMilli())
             .put("jvmVersion", jvmVersion);
     var expectedEvent =
-        new Event("jfr:JVMInformation", expectedAttributes, eventTime.toEpochMilli());
+        new Event("JfrJVMInformation", expectedAttributes, eventTime.toEpochMilli());
     var expected = List.of(expectedEvent);
 
     var event = mock(RecordedEvent.class);

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapperTest.java
@@ -23,7 +23,7 @@ class JVMSystemPropertyMapperTest {
     expectedAttrs.put("jvmProperty", key);
     expectedAttrs.put("jvmPropertyValue", value);
 
-    var expectedEvent = new Event("jfr:JVMInformation", expectedAttrs, startTime.toEpochMilli());
+    var expectedEvent = new Event("JfrJVMInformation", expectedAttrs, startTime.toEpochMilli());
     var expected = List.of(expectedEvent);
 
     var mapper = new JVMSystemPropertyMapper();

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/MethodSampleMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/MethodSampleMapperTest.java
@@ -27,7 +27,7 @@ class MethodSampleMapperTest {
             .put(
                 "stackTrace",
                 "{\"type\":\"stacktrace\",\"language\":\"java\",\"version\":1,\"truncated\":false,\"payload\":[]}");
-    var expectedEvent = new Event("jfr:MethodSample", expectedAttrs, startTime.toEpochMilli());
+    var expectedEvent = new Event("JfrMethodSample", expectedAttrs, startTime.toEpochMilli());
     var expected = List.of(expectedEvent);
 
     var event = mock(RecordedEvent.class);

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/ThreadLockEventMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/ThreadLockEventMapperTest.java
@@ -29,7 +29,7 @@ class ThreadLockEventMapperTest {
             .put("class", monitorClassName)
             .put("duration", duration.toMillis());
     var expectedEvent =
-        new Event("jfr:JavaMonitorWait", expectedAttributes, startTime.toEpochMilli());
+        new Event("JfrJavaMonitorWait", expectedAttributes, startTime.toEpochMilli());
     var expected = List.of(expectedEvent);
 
     var event = mock(RecordedEvent.class);

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/AllocationRequiringGCMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/AllocationRequiringGCMapperTest.java
@@ -27,7 +27,7 @@ class AllocationRequiringGCMapperTest {
     var size = 32784L;
 
     var attr = new Attributes().put("thread.name", eventThread);
-    var gauge = new Gauge("jfr:AllocationRequiringGC.allocationSize", size, now, attr);
+    var gauge = new Gauge("jfr.AllocationRequiringGC.allocationSize", size, now, attr);
     var expected = List.of(gauge);
 
     var testClass = new AllocationRequiringGCMapper();

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/CPUThreadLoadMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/CPUThreadLoadMapperTest.java
@@ -26,8 +26,8 @@ class CPUThreadLoadMapperTest {
 
     Attributes attributes = new Attributes().put("thread.name", threadName);
 
-    Metric gauge1 = new Gauge("jfr:ThreadCPULoad.user", user, timestamp, attributes);
-    Metric gauge2 = new Gauge("jfr:ThreadCPULoad.system", system, timestamp, attributes);
+    Metric gauge1 = new Gauge("jfr.ThreadCPULoad.user", user, timestamp, attributes);
+    Metric gauge2 = new Gauge("jfr.ThreadCPULoad.system", system, timestamp, attributes);
     List<Metric> expected = List.of(gauge1, gauge2);
 
     RecordedEvent event = mock(RecordedEvent.class);

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/ContextSwitchRateMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/ContextSwitchRateMapperTest.java
@@ -21,7 +21,7 @@ class ContextSwitchRateMapperTest {
 
     Gauge expectedGauge =
         new Gauge(
-            "jfr:ThreadContextSwitchRate", switchRate, timestamp.toEpochMilli(), new Attributes());
+            "jfr.ThreadContextSwitchRate", switchRate, timestamp.toEpochMilli(), new Attributes());
 
     RecordedEvent event = mock(RecordedEvent.class);
     when(event.getStartTime()).thenReturn(timestamp);

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/GCHeapSummaryMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/GCHeapSummaryMapperTest.java
@@ -32,9 +32,9 @@ class GCHeapSummaryMapperTest {
     attr.put("committedEnd", committedEnd);
     attr.put("reservedEnd", reservedEnd);
 
-    var gauge1 = new Gauge("jfr:GCHeapSummary.heapUsed", heapUsed, now, attr);
-    var gauge2 = new Gauge("jfr:GCHeapSummary.heapCommittedSize", heapCommittedSize, now, attr);
-    var gauge3 = new Gauge("jfr:GCHeapSummary.reservedSize", reservedSize, now, attr);
+    var gauge1 = new Gauge("jfr.GCHeapSummary.heapUsed", heapUsed, now, attr);
+    var gauge2 = new Gauge("jfr.GCHeapSummary.heapCommittedSize", heapCommittedSize, now, attr);
+    var gauge3 = new Gauge("jfr.GCHeapSummary.reservedSize", reservedSize, now, attr);
     List<Metric> expected = List.of(gauge1, gauge2, gauge3);
 
     var testClass = new GCHeapSummaryMapper();

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/GarbageCollectionMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/GarbageCollectionMapperTest.java
@@ -24,7 +24,7 @@ class GarbageCollectionMapperTest {
     attr.put("name", name);
     attr.put("cause", cause);
     var longestPause = 21.77;
-    var gauge1 = new Gauge("jfr:GarbageCollection.longestPause", longestPause, now, attr);
+    var gauge1 = new Gauge("jfr.GarbageCollection.longestPause", longestPause, now, attr);
     List<Metric> expected = List.of(gauge1);
 
     var testClass = new GarbageCollectionMapper();

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/OverallCPULoadMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/OverallCPULoadMapperTest.java
@@ -23,9 +23,9 @@ class OverallCPULoadMapperTest {
     var jvmUser = 21.77;
     var jvmSystem = 22.98;
     var machineTotal = 1203987.22;
-    var gauge1 = new Gauge("jfr:CPULoad.jvmUser", jvmUser, now, attr);
-    var gauge2 = new Gauge("jfr:CPULoad.jvmSystem", jvmSystem, now, attr);
-    var gauge3 = new Gauge("jfr:CPULoad.machineTotal", machineTotal, now, attr);
+    var gauge1 = new Gauge("jfr.CPULoad.jvmUser", jvmUser, now, attr);
+    var gauge2 = new Gauge("jfr.CPULoad.jvmSystem", jvmSystem, now, attr);
+    var gauge3 = new Gauge("jfr.CPULoad.machineTotal", machineTotal, now, attr);
     List<Metric> expected = List.of(gauge1, gauge2, gauge3);
 
     var testClass = new OverallCPULoadMapper();

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tometric/ThreadAllocationStatisticsMapperTest.java
@@ -26,7 +26,7 @@ class ThreadAllocationStatisticsMapperTest {
     var allocated = 1250229920d;
 
     var attr = new Attributes().put("thread.name", threadName).put("thread.osName", threadOsName);
-    var gauge = new Gauge("jfr:ThreadAllocationStatistics.allocated", allocated, now, attr);
+    var gauge = new Gauge("jfr.ThreadAllocationStatistics.allocated", allocated, now, attr);
     var expected = List.of(gauge);
 
     var testClass = new ThreadAllocationStatisticsMapper();
@@ -50,7 +50,7 @@ class ThreadAllocationStatisticsMapperTest {
     var allocated = 1250229920d;
 
     var attr = new Attributes();
-    var gauge = new Gauge("jfr:ThreadAllocationStatistics.allocated", allocated, now, attr);
+    var gauge = new Gauge("jfr.ThreadAllocationStatistics.allocated", allocated, now, attr);
     var expected = List.of(gauge);
 
     var testClass = new ThreadAllocationStatisticsMapper();

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/G1GarbageCollectionSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/G1GarbageCollectionSummarizerTest.java
@@ -23,7 +23,7 @@ class G1GarbageCollectionSummarizerTest {
   static void init() {
     defaultSummary =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             0,
             Duration.ofNanos(0L).toMillis(),
             Duration.ofNanos(Long.MAX_VALUE).toMillis(),
@@ -45,7 +45,7 @@ class G1GarbageCollectionSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:G1GarbageCollection.duration",
+            "jfr.G1GarbageCollection.duration",
             numOfEvents, // count
             eventDurationMillis, // sum
             eventDurationMillis, // min
@@ -100,7 +100,7 @@ class G1GarbageCollectionSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:G1GarbageCollection.duration",
+            "jfr.G1GarbageCollection.duration",
             numOfEvents, // count
             summedDurationMillis, // sum
             event3DurationMillis, // min

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkReadSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkReadSummarizerTest.java
@@ -27,7 +27,7 @@ class NetworkReadSummarizerTest {
 
     var summary1bytes =
         new Summary(
-            "jfr:SocketRead.bytesRead",
+            "jfr.SocketRead.bytesRead",
             2,
             13 + 17,
             13,
@@ -37,7 +37,7 @@ class NetworkReadSummarizerTest {
             new Attributes().put("thread.name", threadName1));
     var summary1duration =
         new Summary(
-            "jfr:SocketRead.duration",
+            "jfr.SocketRead.duration",
             2,
             Duration.between(time1, time3).toMillis(),
             Duration.between(time2, time3).toMillis(),
@@ -47,7 +47,7 @@ class NetworkReadSummarizerTest {
             new Attributes().put("thread.name", threadName1));
     var summary2bytes =
         new Summary(
-            "jfr:SocketRead.bytesRead",
+            "jfr.SocketRead.bytesRead",
             1,
             12,
             12,
@@ -57,7 +57,7 @@ class NetworkReadSummarizerTest {
             new Attributes().put("thread.name", threadName2));
     var summary2duration =
         new Summary(
-            "jfr:SocketRead.duration",
+            "jfr.SocketRead.duration",
             1,
             Duration.between(time2, time3).toMillis(),
             Duration.between(time2, time3).toMillis(),

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkWriteSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkWriteSummarizerTest.java
@@ -27,7 +27,7 @@ class NetworkWriteSummarizerTest {
 
     var summary1bytes =
         new Summary(
-            "jfr:SocketWrite.bytesWritten",
+            "jfr.SocketWrite.bytesWritten",
             2,
             13 + 17,
             13,
@@ -37,7 +37,7 @@ class NetworkWriteSummarizerTest {
             new Attributes().put("thread.name", threadName1));
     var summary1duration =
         new Summary(
-            "jfr:SocketWrite.duration",
+            "jfr.SocketWrite.duration",
             2,
             Duration.between(time1, time3).toMillis(),
             Duration.between(time2, time3).toMillis(),
@@ -47,7 +47,7 @@ class NetworkWriteSummarizerTest {
             new Attributes().put("thread.name", threadName1));
     var summary2bytes =
         new Summary(
-            "jfr:SocketWrite.bytesWritten",
+            "jfr.SocketWrite.bytesWritten",
             1,
             12,
             12,
@@ -57,7 +57,7 @@ class NetworkWriteSummarizerTest {
             new Attributes().put("thread.name", threadName2));
     var summary2duration =
         new Summary(
-            "jfr:SocketWrite.duration",
+            "jfr.SocketWrite.duration",
             1,
             Duration.between(time2, time3).toMillis(),
             Duration.between(time2, time3).toMillis(),

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationInNewTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationInNewTLABSummarizerTest.java
@@ -22,7 +22,7 @@ class ObjectAllocationInNewTLABSummarizerTest {
   static void init() {
     defaultSummary =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             0,
             0L,
             Long.MAX_VALUE,
@@ -45,7 +45,7 @@ class ObjectAllocationInNewTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             numOfEvents, // count
             eventTlabSize, // sum
             eventTlabSize, // min
@@ -104,7 +104,7 @@ class ObjectAllocationInNewTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             numOfEvents, // count
             summedTlabSize, // sum
             event2TlabSize, // min

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationOutsideTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationOutsideTLABSummarizerTest.java
@@ -22,7 +22,7 @@ class ObjectAllocationOutsideTLABSummarizerTest {
   static void init() {
     defaultSummary =
         new Summary(
-            "jfr:ObjectAllocationOutsideTLAB.allocation",
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
             0,
             0L,
             Long.MAX_VALUE,
@@ -45,7 +45,7 @@ class ObjectAllocationOutsideTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationOutsideTLAB.allocation",
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
             numOfEvents, // count
             eventAllocationSize, // sum
             eventAllocationSize, // min
@@ -104,7 +104,7 @@ class ObjectAllocationOutsideTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationOutsideTLAB.allocation",
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
             numOfEvents, // count
             summedAllocationSize, // sum
             event2AllocationSize, // min

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizerTest.java
@@ -22,7 +22,7 @@ class PerThreadObjectAllocationInNewTLABSummarizerTest {
   static void init() {
     defaultSummary =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             0,
             0L,
             Long.MAX_VALUE,
@@ -45,7 +45,7 @@ class PerThreadObjectAllocationInNewTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             numOfEvents, // count
             eventTlabSize, // sum
             eventTlabSize, // min
@@ -105,7 +105,7 @@ class PerThreadObjectAllocationInNewTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationInNewTLAB.allocation",
+            "jfr.ObjectAllocationInNewTLAB.allocation",
             numOfEvents, // count
             summedTlabSize, // sum
             event2TlabSize, // min

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizerTest.java
@@ -22,7 +22,7 @@ class PerThreadObjectAllocationOutsideTLABSummarizerTest {
   static void init() {
     defaultSummary =
         new Summary(
-            "jfr:ObjectAllocationOutsideTLAB.allocation",
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
             0,
             0L,
             Long.MAX_VALUE,
@@ -45,7 +45,7 @@ class PerThreadObjectAllocationOutsideTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationOutsideTLAB.allocation",
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
             numOfEvents, // count
             eventAllocationSize, // sum
             eventAllocationSize, // min
@@ -105,7 +105,7 @@ class PerThreadObjectAllocationOutsideTLABSummarizerTest {
 
     var expectedSummaryMetric =
         new Summary(
-            "jfr:ObjectAllocationOutsideTLAB.allocation",
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
             numOfEvents, // count
             summedAllocationSize, // sum
             event2AllocationSize, // min


### PR DESCRIPTION
This is to match other event types and metrics. So instead of writing a query like
`SELECT * from `jfr:JVMInformation``
It'll look like
`SELECT * from JfrJVMInformation`

Similar for metrics instead of a query like
`SELECT average(`jfr:MetaspaceSummary.dataSpace.reserved`[count]) from Metric where metricName = 'jfr:MetaspaceSummary.dataSpace.reserved' TIMESERIES `
it'll look like 
`SELECT average(jfr.MetaspaceSummary.dataSpace.reserved[count]) from Metric where metricName = 'jfr.MetaspaceSummary.dataSpace.reserved' TIMESERIES`

Tested locally with the daemon update and it worked.