### PR TITLE
Fix network issue

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EventConverter.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EventConverter.java
@@ -10,6 +10,7 @@ package com.newrelic.jfr.daemon;
 import com.newrelic.jfr.ToEventRegistry;
 import com.newrelic.jfr.ToMetricRegistry;
 import com.newrelic.jfr.ToSummaryRegistry;
+import com.newrelic.jfr.tosummary.EventToSummary;
 import com.newrelic.telemetry.Attributes;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +46,8 @@ public class EventConverter {
         .filter(Objects::nonNull)
         .forEach(recordedEvent -> convertAndBuffer(batches, recordedEvent));
 
-    toSummaryRegistry.all().forEach(s -> s.summarizeAndReset().forEach(batches::addMetric));
+    toSummaryRegistry.all().forEach(s -> s.summarize().forEach(batches::addMetric));
+    toSummaryRegistry.all().forEach(EventToSummary::reset);
 
     logger.info("This conversion had " + eventCount.size() + " events");
     logger.debug("Detailed view of event counts:  " + eventCount.toString());

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
@@ -7,8 +7,6 @@
 
 package com.newrelic.jfr.daemon;
 
-import static com.newrelic.jfr.daemon.AttributeNames.*;
-
 import com.newrelic.telemetry.TelemetryClient;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/EventConverterTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/EventConverterTest.java
@@ -62,7 +62,7 @@ class EventConverterTest {
 
     when(toSummaryRegistry.all()).thenAnswer(x -> Stream.of(eventToSummary));
     when(eventToSummary.test(e3)).thenReturn(true);
-    doReturn(Stream.of(summary)).when(eventToSummary).summarizeAndReset();
+    doReturn(Stream.of(summary)).when(eventToSummary).summarize();
 
     var testClass =
         EventConverter.builder()

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/AbstractThreadDispatchingSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/AbstractThreadDispatchingSummarizer.java
@@ -17,8 +17,14 @@ public abstract class AbstractThreadDispatchingSummarizer implements EventToSumm
   protected final Map<String, EventToSummary> perThread = new HashMap<>();
 
   @Override
-  public Stream<Summary> summarizeAndReset() {
-    return perThread.values().stream().flatMap(EventToSummary::summarizeAndReset);
+  public Stream<Summary> summarize() {
+    Stream<Summary> summaryStream = perThread.values().stream().flatMap(EventToSummary::summarize);
+    return summaryStream;
+  }
+
+  @Override
+  public void reset() {
+    perThread.clear();
   }
 
   public abstract String getEventName();

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/AbstractThreadDispatchingSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/AbstractThreadDispatchingSummarizer.java
@@ -18,8 +18,7 @@ public abstract class AbstractThreadDispatchingSummarizer implements EventToSumm
 
   @Override
   public Stream<Summary> summarize() {
-    Stream<Summary> summaryStream = perThread.values().stream().flatMap(EventToSummary::summarize);
-    return summaryStream;
+    return perThread.values().stream().flatMap(EventToSummary::summarize);
   }
 
   @Override

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/EventToSummary.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/EventToSummary.java
@@ -45,7 +45,10 @@ public interface EventToSummary extends Consumer<RecordedEvent>, Predicate<Recor
    *
    * @return List of Summary metrics for JFR Events
    */
-  Stream<Summary> summarizeAndReset();
+  Stream<Summary> summarize();
+
+  /** Clears the summary information */
+  void reset();
 
   /**
    * Returns the Java version where particular JFR events were added.

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/G1GarbageCollectionSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/G1GarbageCollectionSummarizer.java
@@ -51,7 +51,7 @@ public final class G1GarbageCollectionSummarizer implements EventToSummary {
   }
 
   @Override
-  public Stream<Summary> summarizeAndReset() {
+  public Stream<Summary> summarize() {
     var attr = new Attributes();
     var out =
         new Summary(
@@ -63,7 +63,6 @@ public final class G1GarbageCollectionSummarizer implements EventToSummary {
             startTimeMs,
             endTimeMs,
             attr);
-    reset();
     return Stream.of(out);
   }
 

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkReadSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkReadSummarizer.java
@@ -40,7 +40,7 @@ public class PerThreadNetworkReadSummarizer implements EventToSummary {
   }
 
   @Override
-  public Stream<Summary> summarizeAndReset() {
+  public Stream<Summary> summarize() {
     var attr = new Attributes().put("thread.name", threadName);
     var outRead =
         new Summary(
@@ -62,7 +62,6 @@ public class PerThreadNetworkReadSummarizer implements EventToSummary {
             duration.getStartTimeMs(),
             outRead.getEndTimeMs(),
             attr);
-    reset();
     return Stream.of(outRead, outDuration);
   }
 

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkWriteSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadNetworkWriteSummarizer.java
@@ -40,7 +40,7 @@ public class PerThreadNetworkWriteSummarizer implements EventToSummary {
   }
 
   @Override
-  public Stream<Summary> summarizeAndReset() {
+  public Stream<Summary> summarize() {
     var attr = new Attributes().put("thread.name", threadName);
     var outWritten =
         new Summary(
@@ -63,8 +63,11 @@ public class PerThreadNetworkWriteSummarizer implements EventToSummary {
             duration.getEndTimeMs(),
             attr);
 
+    return Stream.of(outWritten, outDuration);
+  }
+
+  public void reset() {
     bytesSummary.reset();
     duration.reset();
-    return Stream.of(outWritten, outDuration);
   }
 }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizer.java
@@ -46,7 +46,7 @@ public final class PerThreadObjectAllocationInNewTLABSummarizer implements Event
   }
 
   @Override
-  public Stream<Summary> summarizeAndReset() {
+  public Stream<Summary> summarize() {
     var attr = new Attributes().put("thread.name", threadName);
     var out =
         new Summary(
@@ -58,7 +58,6 @@ public final class PerThreadObjectAllocationInNewTLABSummarizer implements Event
             startTimeMs,
             endTimeMs,
             attr);
-    reset();
     return Stream.of(out);
   }
 

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizer.java
@@ -46,7 +46,7 @@ public final class PerThreadObjectAllocationOutsideTLABSummarizer implements Eve
   }
 
   @Override
-  public Stream<Summary> summarizeAndReset() {
+  public Stream<Summary> summarize() {
     var attr = new Attributes().put("thread.name", threadName);
     var out =
         new Summary(
@@ -58,7 +58,6 @@ public final class PerThreadObjectAllocationOutsideTLABSummarizer implements Eve
             startTimeMs,
             endTimeMs,
             attr);
-    reset();
     return Stream.of(out);
   }
 

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkReadSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkReadSummarizerTest.java
@@ -77,9 +77,29 @@ class NetworkReadSummarizerTest {
     summarizer.accept(event2);
     summarizer.accept(event3);
 
-    var result = summarizer.summarizeAndReset();
+    var result = summarizer.summarize();
 
     assertEquals(expected, result.collect(toList()));
+  }
+
+  @Test
+  void testReset() {
+    var threadName1 = "spam";
+    final Instant time1 = Instant.now();
+    final Instant time2 = time1.plus(3, SECONDS);
+
+    var event1 = buildEvent(threadName1, 13, time1, time2);
+
+    NetworkReadSummarizer summarizer = new NetworkReadSummarizer();
+    summarizer.accept(event1);
+
+    var summaries = summarizer.summarize();
+
+    assertEquals(2, summaries.collect(toList()).size());
+
+    summarizer.reset();
+    var emptySummaries = summarizer.summarize();
+    assertEquals(0, emptySummaries.collect(toList()).size());
   }
 
   private RecordedEvent buildEvent(

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkWriteSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/NetworkWriteSummarizerTest.java
@@ -77,9 +77,29 @@ class NetworkWriteSummarizerTest {
     summarizer.accept(event2);
     summarizer.accept(event3);
 
-    var result = summarizer.summarizeAndReset();
+    var result = summarizer.summarize();
 
     assertEquals(expected, result.collect(toList()));
+  }
+
+  @Test
+  void testReset() {
+    var threadName1 = "spam";
+    final Instant time1 = Instant.now();
+    final Instant time2 = time1.plus(3, SECONDS);
+
+    var event1 = buildEvent(threadName1, 13, time1, time2);
+
+    NetworkWriteSummarizer summarizer = new NetworkWriteSummarizer();
+    summarizer.accept(event1);
+
+    var summaries = summarizer.summarize();
+
+    assertEquals(2, summaries.collect(toList()).size());
+
+    summarizer.reset();
+    var emptySummaries = summarizer.summarize();
+    assertEquals(0, emptySummaries.collect(toList()).size());
   }
 
   private RecordedEvent buildEvent(

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationInNewTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationInNewTLABSummarizerTest.java
@@ -2,6 +2,7 @@ package com.newrelic.jfr.tosummary;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +34,7 @@ class ObjectAllocationInNewTLABSummarizerTest {
   }
 
   @Test
-  void testSingleEventSummaryAndReset() {
+  void testSingleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -67,20 +68,12 @@ class ObjectAllocationInNewTLABSummarizerTest {
 
     testClass.accept(event);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
-
+    final List<Summary> result = testClass.summarize().collect(toList());
     assertEquals(expected, result);
-
-    // Summary should be reset to default values
-    assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());
-    assertEquals(defaultSummary.getSum(), resetResultSummary.getSum());
-    assertEquals(defaultSummary.getMin(), resetResultSummary.getMin());
-    assertEquals(defaultSummary.getMax(), resetResultSummary.getMax());
   }
 
   @Test
-  void testMultipleEventSummaryAndReset() {
+  void testMultipleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -137,15 +130,34 @@ class ObjectAllocationInNewTLABSummarizerTest {
     testClass.accept(event2);
     testClass.accept(event3);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
-
+    final List<Summary> result = testClass.summarize().collect(toList());
     assertEquals(expected, result);
+  }
 
-    // Summary should be reset to default values
-    assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());
-    assertEquals(defaultSummary.getSum(), resetResultSummary.getSum());
-    assertEquals(defaultSummary.getMin(), resetResultSummary.getMin());
-    assertEquals(defaultSummary.getMax(), resetResultSummary.getMax());
+  @Test
+  void testReset() {
+    var recordedThread = mock(RecordedThread.class);
+    var eventThreadName = "main";
+
+    var event = mock(RecordedEvent.class);
+    var eventStartTime = Instant.now().toEpochMilli();
+    var eventTlabSize = 847L;
+
+    var testClass = new ObjectAllocationInNewTLABSummarizer();
+
+    when(event.getStartTime()).thenReturn(Instant.ofEpochMilli(eventStartTime));
+    when(event.getValue("eventThread")).thenReturn(recordedThread);
+    when(event.getLong("tlabSize")).thenReturn(eventTlabSize);
+
+    when(recordedThread.getJavaName()).thenReturn(eventThreadName);
+
+    testClass.accept(event);
+
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(1, result.size());
+
+    testClass.reset();
+    final List<Summary> summarizers = testClass.summarize().collect(toList());
+    assertTrue(summarizers.isEmpty());
   }
 }

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationOutsideTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/ObjectAllocationOutsideTLABSummarizerTest.java
@@ -2,6 +2,7 @@ package com.newrelic.jfr.tosummary;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +34,7 @@ class ObjectAllocationOutsideTLABSummarizerTest {
   }
 
   @Test
-  void testSingleEventSummaryAndReset() {
+  void testSingleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -67,20 +68,14 @@ class ObjectAllocationOutsideTLABSummarizerTest {
 
     testClass.accept(event);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
 
     assertEquals(expected, result);
-
-    // Summary should be reset to default values
-    assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());
-    assertEquals(defaultSummary.getSum(), resetResultSummary.getSum());
-    assertEquals(defaultSummary.getMin(), resetResultSummary.getMin());
-    assertEquals(defaultSummary.getMax(), resetResultSummary.getMax());
   }
 
   @Test
-  void testMultipleEventSummaryAndReset() {
+  void testMultipleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -137,15 +132,36 @@ class ObjectAllocationOutsideTLABSummarizerTest {
     testClass.accept(event2);
     testClass.accept(event3);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
 
     assertEquals(expected, result);
+  }
 
-    // Summary should be reset to default values
-    assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());
-    assertEquals(defaultSummary.getSum(), resetResultSummary.getSum());
-    assertEquals(defaultSummary.getMin(), resetResultSummary.getMin());
-    assertEquals(defaultSummary.getMax(), resetResultSummary.getMax());
+  @Test
+  void testReset() {
+    var recordedThread = mock(RecordedThread.class);
+    var eventThreadName = "main";
+
+    var event = mock(RecordedEvent.class);
+    var eventStartTime = Instant.now().toEpochMilli();
+    var eventAllocationSize = 1500L;
+
+    var testClass = new ObjectAllocationOutsideTLABSummarizer();
+
+    when(event.getStartTime()).thenReturn(Instant.ofEpochMilli(eventStartTime));
+    when(event.getValue("eventThread")).thenReturn(recordedThread);
+    when(event.getLong("allocationSize")).thenReturn(eventAllocationSize);
+
+    when(recordedThread.getJavaName()).thenReturn(eventThreadName);
+
+    testClass.accept(event);
+
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(1, result.size());
+
+    testClass.reset();
+    final List<Summary> summarizers = testClass.summarize().collect(toList());
+    assertTrue(summarizers.isEmpty());
   }
 }

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationInNewTLABSummarizerTest.java
@@ -33,7 +33,7 @@ class PerThreadObjectAllocationInNewTLABSummarizerTest {
   }
 
   @Test
-  void testSingleEventSummaryAndReset() {
+  void testSingleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -68,20 +68,14 @@ class PerThreadObjectAllocationInNewTLABSummarizerTest {
 
     testClass.accept(event);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
 
     assertEquals(expected, result);
-
-    // Summary should be reset to default values
-    assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());
-    assertEquals(defaultSummary.getSum(), resetResultSummary.getSum());
-    assertEquals(defaultSummary.getMin(), resetResultSummary.getMin());
-    assertEquals(defaultSummary.getMax(), resetResultSummary.getMax());
   }
 
   @Test
-  void testMultipleEventSummaryAndReset() {
+  void testMultipleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -139,10 +133,51 @@ class PerThreadObjectAllocationInNewTLABSummarizerTest {
     testClass.accept(event2);
     testClass.accept(event3);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
-
+    final List<Summary> result = testClass.summarize().collect(toList());
     assertEquals(expected, result);
+  }
+
+  @Test
+  public void testReset() {
+    var recordedThread = mock(RecordedThread.class);
+    var eventThreadName = "main";
+
+    var event = mock(RecordedEvent.class);
+    var numOfEvents = 1;
+    var eventStartTime = Instant.now().toEpochMilli();
+    var eventTlabSize = 847L;
+    var attr = new Attributes().put("thread.name", eventThreadName);
+
+    var expectedSummaryMetric =
+        new Summary(
+            "jfr.ObjectAllocationInNewTLAB.allocation",
+            numOfEvents, // count
+            eventTlabSize, // sum
+            eventTlabSize, // min
+            eventTlabSize, // max
+            eventStartTime, // startTimeMs: the summary metric startTimeMs is the eventStartTime of
+            // the initial RecordedEvent
+            eventStartTime, // endTimeMs: the summary metric endTimeMs is the eventStartTime of the
+            // last RecordedEvent
+            attr); // attributes contain threadName
+
+    List<Metric> expected = List.of(expectedSummaryMetric);
+    var testClass =
+        new PerThreadObjectAllocationInNewTLABSummarizer(eventThreadName, eventStartTime);
+
+    when(event.getStartTime()).thenReturn(Instant.ofEpochMilli(eventStartTime));
+    when(event.getValue("eventThread")).thenReturn(recordedThread);
+    when(event.getLong("tlabSize")).thenReturn(eventTlabSize);
+
+    when(recordedThread.getJavaName()).thenReturn(eventThreadName);
+
+    testClass.accept(event);
+
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(expected, result);
+
+    testClass.reset();
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
 
     // Summary should be reset to default values
     assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/PerThreadObjectAllocationOutsideTLABSummarizerTest.java
@@ -33,7 +33,7 @@ class PerThreadObjectAllocationOutsideTLABSummarizerTest {
   }
 
   @Test
-  void testSingleEventSummaryAndReset() {
+  void testSingleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -68,20 +68,14 @@ class PerThreadObjectAllocationOutsideTLABSummarizerTest {
 
     testClass.accept(event);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
 
     assertEquals(expected, result);
-
-    // Summary should be reset to default values
-    assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());
-    assertEquals(defaultSummary.getSum(), resetResultSummary.getSum());
-    assertEquals(defaultSummary.getMin(), resetResultSummary.getMin());
-    assertEquals(defaultSummary.getMax(), resetResultSummary.getMax());
   }
 
   @Test
-  void testMultipleEventSummaryAndReset() {
+  void testMultipleEventSummary() {
     var recordedThread = mock(RecordedThread.class);
     var eventThreadName = "main";
 
@@ -139,10 +133,53 @@ class PerThreadObjectAllocationOutsideTLABSummarizerTest {
     testClass.accept(event2);
     testClass.accept(event3);
 
-    final List<Summary> result = testClass.summarizeAndReset().collect(toList());
-    final Summary resetResultSummary = testClass.summarizeAndReset().collect(toList()).get(0);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
 
     assertEquals(expected, result);
+  }
+
+  @Test
+  void testReset() {
+    var recordedThread = mock(RecordedThread.class);
+    var eventThreadName = "main";
+
+    var event = mock(RecordedEvent.class);
+    var numOfEvents = 1;
+    var eventStartTime = Instant.now().toEpochMilli();
+    var eventAllocationSize = 1500L;
+    var attr = new Attributes().put("thread.name", eventThreadName);
+
+    var expectedSummaryMetric =
+        new Summary(
+            "jfr.ObjectAllocationOutsideTLAB.allocation",
+            numOfEvents, // count
+            eventAllocationSize, // sum
+            eventAllocationSize, // min
+            eventAllocationSize, // max
+            eventStartTime, // startTimeMs: the summary metric startTimeMs is the eventStartTime of
+            // the initial RecordedEvent
+            eventStartTime, // endTimeMs: the summary metric endTimeMs is the eventStartTime of the
+            // last RecordedEvent
+            attr); // attributes contain threadName
+
+    List<Metric> expected = List.of(expectedSummaryMetric);
+    var testClass =
+        new PerThreadObjectAllocationOutsideTLABSummarizer(eventThreadName, eventStartTime);
+
+    when(event.getStartTime()).thenReturn(Instant.ofEpochMilli(eventStartTime));
+    when(event.getValue("eventThread")).thenReturn(recordedThread);
+    when(event.getLong("allocationSize")).thenReturn(eventAllocationSize);
+
+    when(recordedThread.getJavaName()).thenReturn(eventThreadName);
+
+    testClass.accept(event);
+
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(expected, result);
+
+    testClass.reset();
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
 
     // Summary should be reset to default values
     assertEquals(defaultSummary.getCount(), resetResultSummary.getCount());


### PR DESCRIPTION
Context: The jfr daemon was causing an increase in network activity over time. The network points of the daemon are the following:
- streaming data from JFR on the service being monitored to the daemon
- writing that stream to a file
- loading that file back to the daemon
- sending events and metrics to New Relic

After eliminating the streaming and file writing and read as the source of the issue, it pointed me to the sending of events/metrics to NR. Looking at one of the test apps it was clear that over time more and more metrics were getting sent each harvest cycle (10 seconds). 

Issue: In some of our summarizers (i.e. ObjectAllocationInNewTLABSummarizer) we keep track of all summarizers in a map based on thread name so we can recall them when reporting data and don't have to recreate them each harvest. The issue with this is that services can have 100s of short lived threads. This becomes an issue because we never clear out our map of threads to summarizers. Each harvest we iterate over that map to summarize the data for each thread and send it up as metrics. If the daemon still had summarizers in that map for threads that no longer existed, then the daemon would send up empty summarizer metrics, which is exactly what was happening. 

Solution: By clearing out the map every harvest we can guarantee that no empty summary metrics will be reported the next harvest. This will lead to recreating summarizers each harvest cycle but that can't be avoided since we can't report up empty metrics.

Here is a graph of the network activity before and after the fix:
<img width="1108" alt="Screen Shot 2020-10-26 at 11 39 20 AM" src="https://user-images.githubusercontent.com/58712431/97214223-014cdf80-1780-11eb-85de-1bbb8f6c0fd5.png">
