### PR TITLE
Add support for Valhalla VBC events

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/MethodSupport.java
@@ -26,6 +26,16 @@ public final class MethodSupport {
     return method.getType().getName() + "." + method.getName() + method.getDescriptor();
   }
 
+  // {"type":"stacktrace","language":"java","version":1,"truncated":false,"payload":[]}
+  public static String empty() {
+    List<Map<String, String>> payload = List.of();
+    try {
+      return new String(jsonWrite(payload, Optional.empty()).getBytes());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to generate stacktrace json", e);
+    }
+  }
+
   public static String serialize(final RecordedStackTrace trace) {
     var payload = new ArrayList<Map<String, String>>();
     var frames = trace.getFrames();

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/ToEventRegistry.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/ToEventRegistry.java
@@ -23,6 +23,7 @@ public class ToEventRegistry {
           new JVMInformationMapper(),
           new JVMSystemPropertyMapper(),
           new ThreadLockEventMapper(),
+          new ValhallaVBCDetector(),
           MethodSampleMapper.forExecutionSample(),
           MethodSampleMapper.forNativeMethodSample());
 

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/ValhallaVBCDetector.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/ValhallaVBCDetector.java
@@ -1,0 +1,45 @@
+package com.newrelic.jfr.toevent;
+
+import com.newrelic.jfr.MethodSupport;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.events.Event;
+import java.util.List;
+import jdk.jfr.consumer.RecordedEvent;
+
+// jdk.SyncOnPrimitiveWrapper {
+//        startTime = 17:16:25.584
+//        boxClass = java.lang.Integer (classLoader = bootstrap)
+//        eventThread = "main" (javaThreadId = 1)
+//        stackTrace = [
+//        com.company.Main.run() line: 21
+//        com.company.Main.main(String[]) line: 10
+//        ]
+//        }
+public class ValhallaVBCDetector implements EventToEvent {
+  // Is this going to change to SyncOnValueBasedClass ?
+  public static final String OLD_EVENT_NAME = "jdk.SyncOnPrimitiveWrapper";
+  public static final String EVENT_NAME = "jdk.SyncOnValueBasedClass";
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean test(RecordedEvent event) {
+    var name = event.getEventType().getName();
+    return name.equalsIgnoreCase(EVENT_NAME) || name.equalsIgnoreCase(OLD_EVENT_NAME);
+  }
+
+  @Override
+  public List<Event> apply(RecordedEvent event) {
+    var timestamp = event.getStartTime().toEpochMilli();
+
+    var attr = new Attributes();
+    attr.put("boxClass", event.getClass("boxClass").getName());
+    attr.put("thread.name", event.getThread("eventThread").getJavaName());
+    attr.put("stackTrace", MethodSupport.serialize(event.getStackTrace()));
+
+    return List.of(new Event("JfrValhallaVBCSync", attr, timestamp));
+  }
+}

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/ValhallaVBCDetectorTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/ValhallaVBCDetectorTest.java
@@ -1,0 +1,52 @@
+package com.newrelic.jfr.toevent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.newrelic.jfr.MethodSupport;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.events.Event;
+import java.time.Instant;
+import java.util.List;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedStackTrace;
+import jdk.jfr.consumer.RecordedThread;
+import org.junit.jupiter.api.Test;
+
+public class ValhallaVBCDetectorTest {
+
+  @Test
+  void testApply() {
+    var startTime = Instant.now();
+    var threadName = "wonder";
+    var expectedAttrs =
+        new Attributes()
+            .put("thread.name", threadName)
+            .put("stackTrace", MethodSupport.empty())
+            .put("boxClass", "java.lang.Integer");
+    var expectedEvent = new Event("JfrValhallaVBCSync", expectedAttrs, startTime.toEpochMilli());
+    var expected = List.of(expectedEvent);
+
+    var event = mock(RecordedEvent.class);
+    var eventThread = mock(RecordedThread.class);
+    var stack = mock(RecordedStackTrace.class);
+    when(stack.getFrames()).thenReturn(List.of());
+    var clazz = mock(RecordedClass.class);
+    when(clazz.getName()).thenReturn("java.lang.Integer");
+
+    when(event.getClass("boxClass")).thenReturn(clazz);
+    when(event.getStartTime()).thenReturn(startTime);
+    when(event.getStackTrace()).thenReturn(stack);
+    when(event.getThread("eventThread")).thenReturn(eventThread);
+
+    when(eventThread.getJavaName()).thenReturn(threadName);
+
+    var mapper = new ValhallaVBCDetector();
+
+    var result = mapper.apply(event);
+
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
This small change adds support for a new type event that is only present in Java 16 and above. It has no impact on anyone not running a Java 16 beta (and even then, requires a command-line flag to be present before these events are generated).