### PR TITLE
Agent / Daemon hybrid

### DIFF
--- a/jfr-daemon/build.gradle.kts
+++ b/jfr-daemon/build.gradle.kts
@@ -26,8 +26,10 @@ dependencies {
 
 tasks.shadowJar {
     archiveClassifier.set("")
+
     manifest {
         attributes(
+                "Premain-Class" to "com.newrelic.jfr.agent.AgentMain",
                 "Main-Class" to "com.newrelic.jfr.daemon.JFRDaemon",
                 "Implementation-Version" to project.version
         )

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/agent/AgentController.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/agent/AgentController.java
@@ -1,0 +1,88 @@
+package com.newrelic.jfr.agent;
+
+import com.newrelic.jfr.daemon.DaemonConfig;
+import com.newrelic.jfr.daemon.JFRUploader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.management.*;
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AgentController {
+  private static final Logger logger = LoggerFactory.getLogger(AgentController.class);
+
+  private final DaemonConfig config;
+  private final JFRUploader uploader;
+  private Recording recording;
+
+  private volatile boolean shutdown = false;
+
+  private final ExecutorService executorService =
+      Executors.newFixedThreadPool(
+          2,
+          r -> {
+            Thread result = new Thread(r, "NRJFRAgent");
+            result.setDaemon(true);
+            return result;
+          });
+
+  public AgentController(JFRUploader uploader, DaemonConfig config) {
+    this.uploader = uploader;
+    this.config = config;
+  }
+
+  // This needs to be exposed to JMX / k8s
+  public void shutdown() {
+    shutdown = true;
+  }
+
+  public void loop(final Duration harvestInterval) throws IOException, JMException {
+    while (!shutdown) {
+      try {
+        TimeUnit.MILLISECONDS.sleep(harvestInterval.toMillis());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        // Ignore the premature return and trigger the next JMX dump at once
+      }
+
+      final var pathToFile = cloneJfrRecording();
+      executorService.submit(() -> uploader.handleFile(pathToFile));
+    }
+    executorService.shutdown();
+  }
+
+  public void startRecording() {
+    final Configuration jfrConfig;
+    try {
+      jfrConfig = Configuration.getConfiguration("profile");
+    } catch (IOException | ParseException e) {
+      // This should never happen
+      throw new RuntimeException(e);
+    }
+    final var recording = new Recording(jfrConfig);
+    recording.setMaxAge(config.getHarvestInterval().plus(10, ChronoUnit.SECONDS));
+    recording.setToDisk(true);
+    recording.setName("New Relic JFR Agent Recording");
+
+    recording.start();
+    this.recording = recording;
+  }
+
+  public Path cloneJfrRecording() throws IOException {
+    final var output = Files.createTempFile("local-recording", ".jfr");
+    // Is this still necessary?
+    //    output.toFile().deleteOnExit();
+    recording.copy(false);
+    recording.dump(output);
+    return output;
+  }
+}

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/agent/AgentMain.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/agent/AgentMain.java
@@ -1,0 +1,58 @@
+package com.newrelic.jfr.agent;
+
+import static com.newrelic.jfr.daemon.JFRDaemon.*;
+
+import com.newrelic.jfr.daemon.*;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.management.JMException;
+import org.slf4j.LoggerFactory;
+
+public class AgentMain {
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(AgentMain.class);
+
+  public static void premain(String agentArgs, Instrumentation inst) {
+    try {
+      Class.forName("jdk.jfr.Recording");
+      Class.forName("jdk.jfr.FlightRecorder");
+    } catch (ClassNotFoundException __) {
+      logger.error("Core JFR APIs do not exist in this JVM, can't attach");
+      return;
+    }
+
+    try {
+      logger.info("Attaching JFR Monitor");
+      new AgentMain().start();
+    } catch (Throwable t) {
+      logger.error("Unable to attach JFR Monitor", t);
+    }
+  }
+
+  private void start() throws IOException, JMException {
+    registerListeners();
+
+    var config = buildConfig();
+    var attr = new JFRCommonAttributes(config).build(Optional.empty());
+    var eventConverter = buildEventConverter(attr);
+    var eventConverterReference = new AtomicReference<>(eventConverter);
+    var readinessCheck = new AtomicBoolean(true);
+    var uploader = buildUploader(config, readinessCheck, eventConverterReference);
+    var jfrController = new AgentController(uploader, config);
+    jfrController.startRecording();
+    var jfrMonitorService = Executors.newSingleThreadExecutor();
+    jfrMonitorService.submit(
+        () -> {
+          try {
+            jfrController.loop(config.getHarvestInterval());
+          } catch (IOException | JMException e) {
+            logger.error("Error in agent, shutting down", e);
+          }
+        });
+  }
+
+  private void registerListeners() {}
+}

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRDaemon.java
@@ -63,7 +63,7 @@ public class JFRDaemon {
     }
   }
 
-  private static DaemonConfig buildConfig() {
+  public static DaemonConfig buildConfig() {
 
     var daemonVersion = new VersionFinder().get();
 
@@ -80,7 +80,7 @@ public class JFRDaemon {
     return builder.build();
   }
 
-  static JFRUploader buildUploader(
+  public static JFRUploader buildUploader(
       DaemonConfig config,
       AtomicBoolean readinessCheck,
       AtomicReference<EventConverter> eventConverterReference)
@@ -96,7 +96,7 @@ public class JFRDaemon {
         .build();
   }
 
-  private static EventConverter buildEventConverter(Attributes attr) {
+  public static EventConverter buildEventConverter(Attributes attr) {
     return EventConverter.builder()
         .commonAttributes(attr)
         .metricMappers(ToMetricRegistry.createDefault())

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRUploader.java
@@ -47,7 +47,7 @@ public final class JFRUploader {
     this.readinessCheck = builder.readinessCheck;
   }
 
-  void handleFile(final Path dumpFile) {
+  public void handleFile(final Path dumpFile) {
     try {
       bufferFileData(dumpFile);
       maybeDrainAndSend();


### PR DESCRIPTION
This PR adds support to launch the JFR connector as either a daemon or an agent.

Note that the agent support is as a standard Java agent, NOT the New Relic agent extension.

The resulting agent is suitable for standalone deployments - i.e. where the New Relic Java agent is NOT present. 