### PR TITLE
revert empty string back to null

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/BaseDurationSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/BaseDurationSummarizer.java
@@ -28,7 +28,7 @@ public abstract class BaseDurationSummarizer {
   }
 
   public BaseDurationSummarizer(long startTimeMs, Supplier<Long> clock) {
-    this(startTimeMs, clock, "");
+    this(startTimeMs, clock, null);
   }
 
   public BaseDurationSummarizer(long startTimeMs, Supplier<Long> clock, String durationName) {


### PR DESCRIPTION
Changing the duration name to an empty string caused a lot of errors to occur. This reverts that change.