### PR TITLE
Catch ConnectIOException so intermittent network failures wont crash …

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/JFRController.java
@@ -8,6 +8,7 @@
 package com.newrelic.jfr.daemon;
 
 import java.io.IOException;
+import java.rmi.ConnectIOException;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -74,7 +75,8 @@ public final class JFRController {
           | MBeanException
           | InstanceNotFoundException
           | OpenDataException
-          | ReflectionException e) {
+          | ReflectionException
+          | ConnectIOException e) {
         logger.error("JMX streaming failed: ", e);
         try {
           restartRecording();


### PR DESCRIPTION
…the daemon

```
16:15:13.201 [main] ERROR com.newrelic.jfr.daemon.JFRDaemon - JFR Daemon is crashing!
java.rmi.ConnectIOException: Exception creating connection to: 10.0.1.7; nested exception is: 
	java.net.SocketException: Network is unreachable (connect failed)
	at sun.rmi.transport.tcp.TCPEndpoint.newSocket(TCPEndpoint.java:635) ~[?:?]
	at sun.rmi.transport.tcp.TCPChannel.createConnection(TCPChannel.java:209) ~[?:?]
	at sun.rmi.transport.tcp.TCPChannel.newConnection(TCPChannel.java:196) ~[?:?]
	at sun.rmi.server.UnicastRef.invoke(UnicastRef.java:132) ~[?:?]
	at jdk.jmx.remote.internal.rmi.PRef.invoke(Unknown Source) ~[?:?]
	at javax.management.remote.rmi.RMIConnectionImpl_Stub.invoke(Unknown Source) ~[?:?]
	at javax.management.remote.rmi.RMIConnector$RemoteMBeanServerConnection.invoke(RMIConnector.java:1021) ~[?:?]
	at com.newrelic.jfr.daemon.JFRJMXRecorder.streamRecordingToFile(JFRJMXRecorder.java:186) ~[jfr-daemon-1.1.0-SNAPSHOT.jar:1.1.0-SNAPSHOT]
```