### PR TITLE
add support for license key.  update doc for proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ JFR files.  It uses these files to build a "pseudo stream" of telemetry events.
 ### How To Use
 
 After building or downloading the jfr-daemon jar, you should first export the INSIGHTS_INSERT_KEY variable
-with [your insights key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key):
+with [your insights key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key) or [license key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/new-relic-api-keys#ingest-license-key):
 
 ```
 $ export INSIGHTS_INSERT_KEY=abc123youractualkeyhere
@@ -108,7 +108,8 @@ default behavior, the following environment variables are recognized:
 
 | env var name          | required? | default             | description  |
 |-----------------------|-----------|---------------------|--------------|
-| INSIGHTS_INSERT_KEY   |     Y     |  n/a                | The New Relic [insert key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key) for your account |
+| INSIGHTS_INSERT_KEY   |     Y     |  n/a                | The New Relic [insert key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key) or [license key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/new-relic-api-keys#ingest-license-key) for your account |
+| USE_LICENSE_KEY    |     N  |  false     | Use a License Key instead of Insights Insert Key.
 | NEW_RELIC_APP_NAME    |     N(!)  |  My Application     | The name of the remote applicaiton being monitored.  You should probably set this so that your application shows up properly in the NR1 platform.
 | REMOTE_JMX_HOST       |     N     |  localhost          | The host to pull JFR data from via JMX        |
 | REMOTE_JMX_PORT       |     N     |  1099               | The port to pull JFR data from via JMX        |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Expose remote JMX on the application that the jfr-daemon will be attaching to by
 
 The JFR daemon logs with the Slf4j-Simple implementation at the default `Info` level. For audit logging from the underlying Telemetry SDK, set the log level to `Debug` and enable audit logging via environment variable as described above. 
 
+### Proxy
+
+Currently, the JFR daemon can not be directly configured to accept a proxy. Instead, please use system properties `-Dhttps.proxyHost` and `-Dhttps.proxyPort` [(reference)](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) to specify your proxy.
+
 ---
 ## Support
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ gsonVersion=2.8.6
 junitVersion=5.6.2
 mockitoVersion=3.3.3
 newRelicAgentVersion=6.1.0
-newRelicTelemetryVersion=0.11.0
+newRelicTelemetryVersion=0.12.0
 okhttpVersion=4.8.0
 slf4jVersion=1.7.30

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/DaemonConfig.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/DaemonConfig.java
@@ -20,6 +20,7 @@ public class DaemonConfig {
   private static final String DEFAULT_JMX_HOST = "localhost";
   private static final boolean DEFAULT_USE_SHARED_FILESYSTEM = false;
   private static final boolean DEFAULT_AUDIT_LOGGING = false;
+  private static final boolean DEFAULT_USE_LICENSE_KEY = false;
   private static final Duration DEFAULT_HARVEST_INTERVAL = Duration.ofSeconds(10);
   private static final String DEFAULT_MONITORED_APP_NAME = "My Application";
 
@@ -33,6 +34,7 @@ public class DaemonConfig {
   private final String daemonVersion;
   private final String monitoredAppName;
   private final boolean auditLogging;
+  private final boolean useLicenseKey;
 
   public DaemonConfig(Builder builder) {
     this.auditLogging = builder.auditLogging;
@@ -42,6 +44,7 @@ public class DaemonConfig {
     this.jmxHost = builder.jmxHost;
     this.jmxPort = builder.jmxPort;
     this.useSharedFilesystem = builder.useSharedFilesystem;
+    this.useLicenseKey = builder.useLicenseKey;
     this.harvestInterval = builder.harvestInterval;
     this.daemonVersion = builder.daemonVersion;
     this.monitoredAppName = builder.monitoredAppName;
@@ -75,6 +78,10 @@ public class DaemonConfig {
     return useSharedFilesystem;
   }
 
+  public boolean isUseLicenseKey() {
+    return useLicenseKey;
+  }
+
   public boolean streamFromJmx() {
     return !useSharedFilesystem;
   }
@@ -97,6 +104,7 @@ public class DaemonConfig {
 
   public static class Builder {
     private boolean auditLogging = DEFAULT_AUDIT_LOGGING;
+    private boolean useLicenseKey = DEFAULT_USE_LICENSE_KEY;
     private String apiKey;
     private URI metricsUri;
     private URI eventsUri;
@@ -139,6 +147,11 @@ public class DaemonConfig {
 
     public Builder useSharedFilesystem(boolean useSharedFilesystem) {
       this.useSharedFilesystem = useSharedFilesystem;
+      return this;
+    }
+
+    public Builder useLicenseKey(boolean useLicenseKey) {
+      this.useLicenseKey = useLicenseKey;
       return this;
     }
 

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EnvironmentVars.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EnvironmentVars.java
@@ -17,6 +17,7 @@ public class EnvironmentVars {
   public static final String REMOTE_JMX_PORT = "REMOTE_JMX_PORT";
   public static final String JFR_SHARED_FILESYSTEM = "JFR_SHARED_FILESYSTEM";
   public static final String AUDIT_LOGGING = "AUDIT_LOGGING";
+  public static final String USE_LICENSE_KEY = "USE_LICENSE_KEY";
 
   private EnvironmentVars() {}
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
@@ -67,6 +67,10 @@ public class SetupUtils {
     builder.maybeEnv(
         EnvironmentVars.JFR_SHARED_FILESYSTEM, Boolean::parseBoolean, builder::useSharedFilesystem);
     builder.maybeEnv(EnvironmentVars.AUDIT_LOGGING, Boolean::parseBoolean, builder::auditLogging);
+    builder.maybeEnv(
+        EnvironmentVars.USE_LICENSE_KEY,
+        Boolean::parseBoolean,
+        useLicenseKey -> builder.useLicenseKey(useLicenseKey));
 
     return builder.build();
   }
@@ -102,6 +106,9 @@ public class SetupUtils {
     if (config.getEventsUri() != null) {
       eventsConfig = eventsConfig.endpoint(toURL(config.getEventsUri()));
     }
+    if (config.isUseLicenseKey()) {
+      eventsConfig = eventsConfig.useLicenseKey(true);
+    }
     return EventBatchSender.create(eventsConfig.build());
   }
 
@@ -114,6 +121,9 @@ public class SetupUtils {
             .auditLoggingEnabled(config.auditLogging());
     if (config.getMetricsUri() != null) {
       metricConfig = metricConfig.endpoint(toURL(config.getMetricsUri()));
+    }
+    if (config.isUseLicenseKey()) {
+      metricConfig = metricConfig.useLicenseKey(true);
     }
     return MetricBatchSender.create(metricConfig.build());
   }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/app/JmxJfrRecorderFactory.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/app/JmxJfrRecorderFactory.java
@@ -11,10 +11,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
-import javax.management.JMException;
-import javax.management.MBeanServerConnection;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
+import javax.management.*;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.CompositeType;
@@ -62,6 +59,9 @@ public class JmxJfrRecorderFactory implements JfrRecorderFactory {
     while (true) {
       try {
         return startRecording(connection);
+      } catch (InstanceNotFoundException e) {
+        // JFR recorder MBean is missing.
+        throw e;
       } catch (Exception e) {
         long backoffMillis = backoff.nextWaitMs();
         if (backoffMillis == -1) {

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -1,7 +1,7 @@
 import de.undercouch.gradle.tasks.download.Download
 
 plugins {
-    id("org.springframework.boot") version "2.4.1"
+    id("org.springframework.boot") version "2.4.3"
     id("io.spring.dependency-management") version "1.0.10.RELEASE"
     id("de.undercouch.download") version "4.1.1"
 }


### PR DESCRIPTION
JFRD will accept a New Relic license key or the Insights Insert Key. 

Confirmed with manual testing -  Resolves #156 

Throw exception and shutdown JFRD if target does not have the Flight Recorder MBean.  The output to the user is clearer. Resolves #162 

```
[main] ERROR com.newrelic.jfr.daemon.app.JFRDaemon - JFR Daemon is crashing!
com.newrelic.jfr.daemon.JfrRecorderException: Failed to obtain JfrRecorder.
        at com.newrelic.jfr.daemon.app.JmxJfrRecorderFactory.getRecorder(JmxJfrRecorderFactory.java:53)
        at com.newrelic.jfr.daemon.JfrController.resetJfrRecorder(JfrController.java:79)
        at com.newrelic.jfr.daemon.JfrController.loop(JfrController.java:60)
        at com.newrelic.jfr.daemon.app.JFRDaemon.main(JFRDaemon.java:58)
Caused by: javax.management.InstanceNotFoundException: jdk.management.jfr:type=FlightRecorder
...
```

Updated the doc with the current recommendation for setting a proxy, for #158 