### PR TITLE
enable jar task for daemon

### DIFF
--- a/jfr-daemon/build.gradle.kts
+++ b/jfr-daemon/build.gradle.kts
@@ -30,8 +30,9 @@ dependencies {
 }
 
 tasks.jar {
-    // Create shadowJar instead of jar
-    enabled = false
+    //jfr agent extension needs the daemon jar
+    archiveClassifier.set("not_shadow")
+    enabled = true
 }
 
 tasks.shadowJar {


### PR DESCRIPTION
This will package the daemon jar into the jfr-agent-extension, so that the extension works and can attach. Thanks @jack-berg  for finding the solution!

The snyk security issue is a test issue and will be fixed when #163  is merged.