### PR TITLE
Add basic gc summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ default behavior, the following environment variables are recognized:
 | env var name          | required? | default             | description  |
 |-----------------------|-----------|---------------------|--------------|
 | INSIGHTS_INSERT_KEY   |     Y     |  n/a                | The New Relic [insert key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key) or [license key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/new-relic-api-keys#ingest-license-key) for your account |
-| USE_LICENSE_KEY    |     N  |  false     | Use a License Key instead of Insights Insert Key.
-| NEW_RELIC_APP_NAME    |     N(!)  |  My Application     | The name of the remote applicaiton being monitored.  You should probably set this so that your application shows up properly in the NR1 platform.
+| USE_LICENSE_KEY       |     N     |  false              | Use a License Key instead of Insights Insert Key.
+| NEW_RELIC_APP_NAME    |     N(!)  |  My Application     | The name of the remote application being monitored.  You should probably set this so that your application shows up properly in the NR1 platform.
 | REMOTE_JMX_HOST       |     N     |  localhost          | The host to pull JFR data from via JMX        |
 | REMOTE_JMX_PORT       |     N     |  1099               | The port to pull JFR data from via JMX        |
 | METRICS_INGEST_URI    |     N     |  [US production](https://metric-api.newrelic.com/metric/v1), [EU production](https://metric-api.eu.newrelic.com/metric/v1)          | Where to send metric data
 | EVENTS_INGEST_URI     |     N     |  [US production](https://insights-collector.newrelic.com/v1/accounts/events), [EU production](https://insights-collector.eu01.nr-data.net/v1/accounts/events) | Where to send event data
 | JFR_SHARED_FILESYSTEM |     N     |  false              | Use a shared filesystem instead of streaming data from JMX
-| AUDIT_LOGGING |     N     |  false              | [Enables audit logging](https://github.com/newrelic/newrelic-telemetry-sdk-java#enabling-audit-logging) in the underlying Telemetry SDK
+| AUDIT_LOGGING         |     N     |  false              | [Enables audit logging](https://github.com/newrelic/newrelic-telemetry-sdk-java#enabling-audit-logging) in the underlying Telemetry SDK
 
 Expose remote JMX on the application that the jfr-daemon will be attaching to by adding the following system properties:
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Expose remote JMX on the application that the jfr-daemon will be attaching to by
 -Dcom.sun.management.jmxremote.ssl=false 
 -Dcom.sun.management.jmxremote.authenticate=false
 ```
+
 ### Logging
 
 The JFR daemon logs with the Slf4j-Simple implementation at the default `Info` level. For audit logging from the underlying Telemetry SDK, set the log level to `Debug` and enable audit logging via environment variable as described above. 

--- a/jfr-mappers/build.gradle.kts
+++ b/jfr-mappers/build.gradle.kts
@@ -1,9 +1,11 @@
 val newRelicTelemetryVersion: String by project
 val gsonVersion: String by project
+val slf4jVersion: String by project
 
 dependencies {
     implementation("com.newrelic.telemetry:telemetry-core:${newRelicTelemetryVersion}")
     implementation("com.google.code.gson:gson:${gsonVersion}")
+    implementation("org.slf4j:slf4j-simple:${slf4jVersion}");
 }
 
 // Main source set compiles against java 8

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
@@ -9,6 +9,7 @@ package com.newrelic.jfr;
 
 import static java.util.stream.Collectors.toList;
 
+import com.newrelic.jfr.tosummary.BasicGarbageCollectionSummarizer;
 import com.newrelic.jfr.tosummary.EventToSummary;
 import com.newrelic.jfr.tosummary.G1GarbageCollectionSummarizer;
 import com.newrelic.jfr.tosummary.GCHeapSummarySummarizer;
@@ -26,6 +27,7 @@ public class ToSummaryRegistry {
 
   private static final List<EventToSummary> ALL_MAPPERS =
       Arrays.asList(
+          new BasicGarbageCollectionSummarizer(),
           new G1GarbageCollectionSummarizer(),
           new GCHeapSummarySummarizer(),
           new NetworkReadSummarizer(),

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizer.java
@@ -1,0 +1,144 @@
+/*
+ *
+ *  * Copyright 2020 New Relic Corporation. All rights reserved.
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.newrelic.jfr.tosummary;
+
+import static com.newrelic.jfr.tosummary.BaseDurationSummarizer.DEFAULT_CLOCK;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.metrics.Summary;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import jdk.jfr.consumer.RecordedEvent;
+
+/** This class aggregates the duration of Garbage Collection JFR events */
+public final class BasicGarbageCollectionSummarizer implements EventToSummary {
+
+  public static final String EVENT_NAME = "jdk.GarbageCollection";
+
+  private final SimpleDurationSummarizer minorGcDurationSummarizer;
+  private final SimpleDurationSummarizer majorGcDurationSummarizer;
+  private int minorGcCount = 0;
+  private int majorGcCount = 0;
+  private long startTimeMs;
+  private long minorGcEndTimeMs = 0L;
+  private long majorGcEndTimeMs = 0L;
+
+  // TODO figure out exhaustive list of all minor/major GC names
+  private static final Set<String> MINOR_GC_NAMES =
+      new HashSet<String>() {
+        {
+          add("G1New");
+          add("ParNew");
+        }
+      };
+
+  private static final Set<String> MAJOR_GC_NAMES =
+      new HashSet<String>() {
+        {
+          add("G1Old");
+          add("ParallelOld");
+        }
+      };
+
+  public BasicGarbageCollectionSummarizer() {
+    this(Instant.now().toEpochMilli());
+  }
+
+  public BasicGarbageCollectionSummarizer(long startTimeMs) {
+    this(
+        startTimeMs,
+        new SimpleDurationSummarizer(startTimeMs, DEFAULT_CLOCK, "duration"),
+        new SimpleDurationSummarizer(startTimeMs, DEFAULT_CLOCK, "duration"));
+  }
+
+  public BasicGarbageCollectionSummarizer(
+      long startTimeMs,
+      SimpleDurationSummarizer minorGcDurationSummarizer,
+      SimpleDurationSummarizer majorGcDurationSummarizer) {
+    // TODO do we need a different start time for minor/major? Only end time?
+    this.startTimeMs = startTimeMs;
+    this.minorGcDurationSummarizer = minorGcDurationSummarizer;
+    this.majorGcDurationSummarizer = majorGcDurationSummarizer;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void accept(RecordedEvent ev) {
+    final String name = ev.getValue("name");
+    if (name != null) {
+      if (MINOR_GC_NAMES.contains(name)) {
+        minorGcEndTimeMs = ev.getStartTime().toEpochMilli();
+        minorGcDurationSummarizer.accept(ev);
+        minorGcCount++;
+      } else if (MAJOR_GC_NAMES.contains(name)) {
+        majorGcEndTimeMs = ev.getStartTime().toEpochMilli();
+        majorGcDurationSummarizer.accept(ev);
+        majorGcCount++;
+      }
+    }
+  }
+
+  // Metric types TODO Do we need all four or is the count included in duration sufficient?
+  //    jfr.GarbageCollection.minorCount
+  //    jfr.GarbageCollection.minorDuration
+  //    jfr.GarbageCollection.majorCount
+  //    jfr.GarbageCollection.majorDuration
+
+  // Example JFR event
+  //    jdk.GarbageCollection {
+  //        startTime = 11:52:18.076
+  //        duration = 0.502 ms
+  //        gcId = 859
+  //        name = "G1New"
+  //        cause = "G1 Evacuation Pause"
+  //        sumOfPauses = 0.502 ms
+  //        longestPause = 0.502 ms
+  //    }
+  @Override
+  public Stream<Summary> summarize() {
+    Attributes attr = new Attributes();
+    Summary minorGcDuration =
+        new Summary(
+            "jfr.GarbageCollection.minorDuration",
+            minorGcCount, // TODO should count move to a jfr.GarbageCollection.minorCount metric?
+            minorGcDurationSummarizer.getDurationMillis(),
+            minorGcDurationSummarizer.getMinDurationMillis(),
+            minorGcDurationSummarizer.getMaxDurationMillis(),
+            startTimeMs,
+            minorGcEndTimeMs,
+            attr);
+
+    Summary majorGcDuration =
+        new Summary(
+            "jfr.GarbageCollection.majorDuration",
+            majorGcCount, // TODO should count move to a jfr.GarbageCollection.majorCount
+            majorGcDurationSummarizer.getDurationMillis(),
+            majorGcDurationSummarizer.getMinDurationMillis(),
+            majorGcDurationSummarizer.getMaxDurationMillis(),
+            startTimeMs,
+            majorGcEndTimeMs,
+            attr);
+    return Stream.of(minorGcDuration, majorGcDuration);
+  }
+
+  public void reset() {
+    startTimeMs = Instant.now().toEpochMilli();
+    minorGcEndTimeMs = 0L;
+    majorGcEndTimeMs = 0L;
+    minorGcCount = 0;
+    majorGcCount = 0;
+    minorGcDurationSummarizer.reset();
+    majorGcDurationSummarizer.reset();
+  }
+}

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizerTest.java
@@ -1,0 +1,20 @@
+package com.newrelic.jfr.tosummary;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.metrics.Metric;
+import com.newrelic.telemetry.metrics.Summary;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class BasicGarbageCollectionSummarizerTest {
+    // TODO write tests
+}

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizerTest.java
@@ -16,5 +16,270 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class BasicGarbageCollectionSummarizerTest {
-    // TODO write tests
+  private static Summary defaultMinorGcSummary;
+  private static Summary defaultMajorGcSummary;
+  private static final long DEFAULT_SUM = Duration.ofNanos(0L).toMillis();
+  private static final long DEFAULT_MIN = Duration.ofNanos(Long.MAX_VALUE).toMillis();
+  private static final long DEFAULT_MAX = Duration.ofNanos(Long.MIN_VALUE).toMillis();
+  private static final int DEFAULT_COUNT = 0;
+  private static final long DEFAULT_START_TIME_MS = Instant.now().toEpochMilli();
+  private static final long DEFAULT_END_TIME_MS = 0L;
+  private static final String MINOR_GC_DURATION_METRIC_NAME = "jfr.GarbageCollection.minorDuration";
+  private static final String MAJOR_GC_DURATION_METRIC_NAME = "jfr.GarbageCollection.majorDuration";
+
+  @BeforeAll
+  static void init() {
+    defaultMinorGcSummary =
+        new Summary(
+            MINOR_GC_DURATION_METRIC_NAME,
+            DEFAULT_COUNT,
+            DEFAULT_SUM,
+            DEFAULT_MIN,
+            DEFAULT_MAX,
+            DEFAULT_START_TIME_MS,
+            DEFAULT_END_TIME_MS,
+            new Attributes());
+
+    defaultMajorGcSummary =
+        new Summary(
+            MAJOR_GC_DURATION_METRIC_NAME,
+            DEFAULT_COUNT,
+            DEFAULT_SUM,
+            DEFAULT_MIN,
+            DEFAULT_MAX,
+            DEFAULT_START_TIME_MS,
+            DEFAULT_END_TIME_MS,
+            new Attributes());
+  }
+
+  @Test
+  void testSingleMinorGcEventSummary() {
+    var event = mock(RecordedEvent.class);
+    var numOfEvents = 1;
+    var eventStartTime = DEFAULT_START_TIME_MS + 1;
+    var eventDurationNanos = 13_700_000;
+    var eventDurationMillis = Duration.ofNanos(eventDurationNanos).toMillis();
+
+    var expectedMinorGcSummaryMetric =
+        new Summary(
+            MINOR_GC_DURATION_METRIC_NAME,
+            numOfEvents, // count
+            eventDurationMillis, // sum
+            eventDurationMillis, // min
+            eventDurationMillis, // max
+            DEFAULT_START_TIME_MS, // startTimeMs
+            eventStartTime, // endTimeMs
+            new Attributes());
+
+    List<Metric> expected = List.of(expectedMinorGcSummaryMetric, defaultMajorGcSummary);
+    var testClass = new BasicGarbageCollectionSummarizer(DEFAULT_START_TIME_MS);
+
+    when(event.getValue("name")).thenReturn("G1New");
+    when(event.getStartTime()).thenReturn(Instant.ofEpochMilli(eventStartTime));
+    when(event.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    testClass.accept(event);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(expected, result);
+
+    for (Summary summary : result) {
+      var summaryName = summary.getName();
+      if (summaryName.equals(MINOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(numOfEvents, summary.getCount());
+      } else if (summaryName.equals(MAJOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(DEFAULT_COUNT, summary.getCount());
+      }
+    }
+  }
+
+  @Test
+  void testSingleMajorGcEventSummary() {
+    var event = mock(RecordedEvent.class);
+    var numOfEvents = 1;
+    var eventStartTime = DEFAULT_START_TIME_MS + 1;
+    var eventDurationNanos = 13_700_000;
+    var eventDurationMillis = Duration.ofNanos(eventDurationNanos).toMillis();
+
+    var expectedMajorGcSummaryMetric =
+        new Summary(
+            MAJOR_GC_DURATION_METRIC_NAME,
+            numOfEvents, // count
+            eventDurationMillis, // sum
+            eventDurationMillis, // min
+            eventDurationMillis, // max
+            DEFAULT_START_TIME_MS, // startTimeMs
+            eventStartTime, // endTimeMs
+            new Attributes());
+
+    List<Metric> expected = List.of(defaultMinorGcSummary, expectedMajorGcSummaryMetric);
+    var testClass = new BasicGarbageCollectionSummarizer(DEFAULT_START_TIME_MS);
+
+    when(event.getValue("name")).thenReturn("G1Old");
+    when(event.getStartTime()).thenReturn(Instant.ofEpochMilli(eventStartTime));
+    when(event.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    testClass.accept(event);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(expected, result);
+
+    for (Summary summary : result) {
+      var summaryName = summary.getName();
+      if (summaryName.equals(MAJOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(numOfEvents, summary.getCount());
+      } else if (summaryName.equals(MINOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(DEFAULT_COUNT, summary.getCount());
+      }
+    }
+  }
+
+  @Test
+  void testMultipleGcEventSummariesOfBothTypesAndReset() {
+    var numOfMinorGcEvents = 4;
+    var minorGcEvent1 = mock(RecordedEvent.class);
+    var minorGcEvent2 = mock(RecordedEvent.class);
+    var minorGcEvent3 = mock(RecordedEvent.class);
+    var minorGcEvent4 = mock(RecordedEvent.class);
+
+    var numOfMajorGcEvents = 4;
+    var majorGcEvent5 = mock(RecordedEvent.class);
+    var majorGcEvent6 = mock(RecordedEvent.class);
+    var majorGcEvent7 = mock(RecordedEvent.class);
+    var majorGcEvent8 = mock(RecordedEvent.class);
+
+    var startTimeEvent1 = DEFAULT_START_TIME_MS + 1;
+    var startTimeEvent2 = ++startTimeEvent1;
+    var startTimeEvent3 = ++startTimeEvent2;
+    var startTimeEvent4 = ++startTimeEvent3;
+    var startTimeEvent5 = ++startTimeEvent4;
+    var startTimeEvent6 = ++startTimeEvent5;
+    var startTimeEvent7 = ++startTimeEvent6;
+    var startTimeEvent8 = ++startTimeEvent7;
+
+    var eventDurationNanos = 13_700_000;
+    var eventDurationMillis = Duration.ofNanos(eventDurationNanos).toMillis();
+    var minorGcDurationSum = Duration.ofNanos(eventDurationNanos * numOfMinorGcEvents).toMillis();
+    var majorGcDurationSum = Duration.ofNanos(eventDurationNanos * numOfMajorGcEvents).toMillis();
+
+    var expectedMinorGcSummaryMetric =
+        new Summary(
+            MINOR_GC_DURATION_METRIC_NAME,
+            numOfMinorGcEvents, // count
+            minorGcDurationSum, // sum
+            eventDurationMillis, // min
+            eventDurationMillis, // max
+            DEFAULT_START_TIME_MS, // startTimeMs
+            startTimeEvent4, // endTimeMs
+            new Attributes());
+
+    var expectedMajorGcSummaryMetric =
+        new Summary(
+            MAJOR_GC_DURATION_METRIC_NAME,
+            numOfMajorGcEvents, // count
+            majorGcDurationSum, // sum
+            eventDurationMillis, // min
+            eventDurationMillis, // max
+            DEFAULT_START_TIME_MS, // startTimeMs
+            startTimeEvent8, // endTimeMs
+            new Attributes());
+
+    List<Metric> expected = List.of(expectedMinorGcSummaryMetric, expectedMajorGcSummaryMetric);
+    var testClass = new BasicGarbageCollectionSummarizer(DEFAULT_START_TIME_MS);
+
+    // minor GC events
+    when(minorGcEvent1.getValue("name")).thenReturn("ParNew");
+    when(minorGcEvent1.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent1));
+    when(minorGcEvent1.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    when(minorGcEvent2.getValue("name")).thenReturn("DefNew");
+    when(minorGcEvent2.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent2));
+    when(minorGcEvent2.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    when(minorGcEvent3.getValue("name")).thenReturn("PSMarkSweep");
+    when(minorGcEvent3.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent3));
+    when(minorGcEvent3.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    when(minorGcEvent4.getValue("name")).thenReturn("ParallelScavenge");
+    when(minorGcEvent4.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent4));
+    when(minorGcEvent4.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    // major GC events
+    when(majorGcEvent5.getValue("name")).thenReturn("ParallelOld");
+    when(majorGcEvent5.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent5));
+    when(majorGcEvent5.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    when(majorGcEvent6.getValue("name")).thenReturn("SerialOld");
+    when(majorGcEvent6.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent6));
+    when(majorGcEvent6.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    when(majorGcEvent7.getValue("name")).thenReturn("ConcurrentMarkSweep");
+    when(majorGcEvent7.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent7));
+    when(majorGcEvent7.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    when(majorGcEvent8.getValue("name")).thenReturn("G1Full");
+    when(majorGcEvent8.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent8));
+    when(majorGcEvent8.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    testClass.accept(minorGcEvent1);
+    testClass.accept(minorGcEvent2);
+    testClass.accept(minorGcEvent3);
+    testClass.accept(minorGcEvent4);
+
+    testClass.accept(majorGcEvent5);
+    testClass.accept(majorGcEvent6);
+    testClass.accept(majorGcEvent7);
+    testClass.accept(majorGcEvent8);
+
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(expected, result);
+
+    for (Summary summary : result) {
+      var summaryName = summary.getName();
+      if (summaryName.equals(MINOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(numOfMinorGcEvents, summary.getCount());
+      } else if (summaryName.equals(MAJOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(numOfMajorGcEvents, summary.getCount());
+      }
+    }
+
+    testClass.reset();
+    final Summary resetResultSummary = testClass.summarize().collect(toList()).get(0);
+
+    // Minor and Major GC summaries should be reset to default values
+    assertEquals(defaultMinorGcSummary.getCount(), resetResultSummary.getCount());
+    assertEquals(defaultMinorGcSummary.getSum(), resetResultSummary.getSum());
+    assertEquals(defaultMinorGcSummary.getMin(), resetResultSummary.getMin());
+    assertEquals(defaultMinorGcSummary.getMax(), resetResultSummary.getMax());
+
+    assertEquals(defaultMajorGcSummary.getCount(), resetResultSummary.getCount());
+    assertEquals(defaultMajorGcSummary.getSum(), resetResultSummary.getSum());
+    assertEquals(defaultMajorGcSummary.getMin(), resetResultSummary.getMin());
+    assertEquals(defaultMajorGcSummary.getMax(), resetResultSummary.getMax());
+  }
+
+  @Test
+  void testUnsupportedGcEventName() {
+    var event = mock(RecordedEvent.class);
+    var eventStartTime = DEFAULT_START_TIME_MS + 1;
+    var eventDurationNanos = 13_700_000;
+
+    List<Metric> expected = List.of(defaultMinorGcSummary, defaultMajorGcSummary);
+    var testClass = new BasicGarbageCollectionSummarizer(DEFAULT_START_TIME_MS);
+
+    when(event.getValue("name")).thenReturn("FOO");
+    when(event.getStartTime()).thenReturn(Instant.ofEpochMilli(eventStartTime));
+    when(event.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
+
+    testClass.accept(event);
+    final List<Summary> result = testClass.summarize().collect(toList());
+    assertEquals(expected, result);
+
+    for (Summary summary : result) {
+      var summaryName = summary.getName();
+      if (summaryName.equals(MINOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(DEFAULT_COUNT, summary.getCount());
+      } else if (summaryName.equals(MAJOR_GC_DURATION_METRIC_NAME)) {
+        assertEquals(DEFAULT_COUNT, summary.getCount());
+      }
+    }
+  }
 }

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizerTest.java
@@ -11,6 +11,7 @@ import com.newrelic.telemetry.metrics.Summary;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import jdk.jfr.consumer.RecordedEvent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -146,14 +147,14 @@ class BasicGarbageCollectionSummarizerTest {
     var majorGcEvent7 = mock(RecordedEvent.class);
     var majorGcEvent8 = mock(RecordedEvent.class);
 
-    var startTimeEvent1 = DEFAULT_START_TIME_MS + 1;
-    var startTimeEvent2 = ++startTimeEvent1;
-    var startTimeEvent3 = ++startTimeEvent2;
-    var startTimeEvent4 = ++startTimeEvent3;
-    var startTimeEvent5 = ++startTimeEvent4;
-    var startTimeEvent6 = ++startTimeEvent5;
-    var startTimeEvent7 = ++startTimeEvent6;
-    var startTimeEvent8 = ++startTimeEvent7;
+    var startTimeEvent1 = new AtomicLong(DEFAULT_START_TIME_MS + 1);
+    var startTimeEvent2 = new AtomicLong(startTimeEvent1.incrementAndGet());
+    var startTimeEvent3 = new AtomicLong(startTimeEvent2.incrementAndGet());
+    var startTimeEvent4 = new AtomicLong(startTimeEvent3.incrementAndGet());
+    var startTimeEvent5 = new AtomicLong(startTimeEvent4.incrementAndGet());
+    var startTimeEvent6 = new AtomicLong(startTimeEvent5.incrementAndGet());
+    var startTimeEvent7 = new AtomicLong(startTimeEvent6.incrementAndGet());
+    var startTimeEvent8 = new AtomicLong(startTimeEvent7.incrementAndGet());
 
     var eventDurationNanos = 13_700_000;
     var eventDurationMillis = Duration.ofNanos(eventDurationNanos).toMillis();
@@ -168,7 +169,7 @@ class BasicGarbageCollectionSummarizerTest {
             eventDurationMillis, // min
             eventDurationMillis, // max
             DEFAULT_START_TIME_MS, // startTimeMs
-            startTimeEvent4, // endTimeMs
+            startTimeEvent4.get(), // endTimeMs
             new Attributes());
 
     var expectedMajorGcSummaryMetric =
@@ -179,7 +180,7 @@ class BasicGarbageCollectionSummarizerTest {
             eventDurationMillis, // min
             eventDurationMillis, // max
             DEFAULT_START_TIME_MS, // startTimeMs
-            startTimeEvent8, // endTimeMs
+            startTimeEvent8.get(), // endTimeMs
             new Attributes());
 
     List<Metric> expected = List.of(expectedMinorGcSummaryMetric, expectedMajorGcSummaryMetric);
@@ -187,36 +188,36 @@ class BasicGarbageCollectionSummarizerTest {
 
     // minor GC events
     when(minorGcEvent1.getValue("name")).thenReturn("ParNew");
-    when(minorGcEvent1.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent1));
+    when(minorGcEvent1.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent1.get()));
     when(minorGcEvent1.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     when(minorGcEvent2.getValue("name")).thenReturn("DefNew");
-    when(minorGcEvent2.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent2));
+    when(minorGcEvent2.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent2.get()));
     when(minorGcEvent2.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     when(minorGcEvent3.getValue("name")).thenReturn("PSMarkSweep");
-    when(minorGcEvent3.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent3));
+    when(minorGcEvent3.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent3.get()));
     when(minorGcEvent3.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     when(minorGcEvent4.getValue("name")).thenReturn("ParallelScavenge");
-    when(minorGcEvent4.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent4));
+    when(minorGcEvent4.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent4.get()));
     when(minorGcEvent4.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     // major GC events
     when(majorGcEvent5.getValue("name")).thenReturn("ParallelOld");
-    when(majorGcEvent5.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent5));
+    when(majorGcEvent5.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent5.get()));
     when(majorGcEvent5.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     when(majorGcEvent6.getValue("name")).thenReturn("SerialOld");
-    when(majorGcEvent6.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent6));
+    when(majorGcEvent6.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent6.get()));
     when(majorGcEvent6.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     when(majorGcEvent7.getValue("name")).thenReturn("ConcurrentMarkSweep");
-    when(majorGcEvent7.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent7));
+    when(majorGcEvent7.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent7.get()));
     when(majorGcEvent7.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     when(majorGcEvent8.getValue("name")).thenReturn("G1Full");
-    when(majorGcEvent8.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent8));
+    when(majorGcEvent8.getStartTime()).thenReturn(Instant.ofEpochMilli(startTimeEvent8.get()));
     when(majorGcEvent8.getDuration("duration")).thenReturn(Duration.ofNanos(eventDurationNanos));
 
     testClass.accept(minorGcEvent1);


### PR DESCRIPTION
Adds `BasicGarbageCollectionSummarizer` to create `jfr.GarbageCollection.minorDuration` and `jfr.GarbageCollection.majorDuration` metrics. These metrics include the count.

```
        {
          "app.name": "jfr-daemon",
          "collector.name": "JFR-Uploader",
          "endTimestamp": 1615421055034,
          "entity.guid": "MjIxMjg2NHxFWFR8U0VSVklDRXwtODc2Mzc1ODMwMzk3NDAwNDM2OQ",
          "entity.name": "jfr-daemon",
          "host.hostname": "C02XQ1RKJG5J/192.168.1.23",
          "instrumentation.name": "JFR",
          "instrumentation.provider": "JFR-Uploader",
          "jfr.GarbageCollection.minorDuration": {
            "type": "summary",
            "count": 490,
            "sum": 1202,
            "min": 0,
            "max": 11
          },
          "metricName": "jfr.GarbageCollection.minorDuration",
          "newrelic.source": "metricAPI",
          "nr.entity.type": "SERVICE",
          "service.name": "jfr-daemon",
          "timestamp": 1615421045052
        }
```

```
        {
          "app.name": "jfr-daemon",
          "collector.name": "JFR-Uploader",
          "endTimestamp": 1615421054939,
          "entity.guid": "MjIxMjg2NHxFWFR8U0VSVklDRXwtODc2Mzc1ODMwMzk3NDAwNDM2OQ",
          "entity.name": "jfr-daemon",
          "host.hostname": "C02XQ1RKJG5J/192.168.1.23",
          "instrumentation.name": "JFR",
          "instrumentation.provider": "JFR-Uploader",
          "jfr.GarbageCollection.majorDuration": {
            "type": "summary",
            "count": 501,
            "sum": 20280,
            "min": 38,
            "max": 50
          },
          "metricName": "jfr.GarbageCollection.majorDuration",
          "newrelic.source": "metricAPI",
          "nr.entity.type": "SERVICE",
          "service.name": "jfr-daemon",
          "timestamp": 1615421045052
        }
```

Resolves #150 