### PR TITLE
Split large attribute values

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/ToEventRegistry.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/ToEventRegistry.java
@@ -22,7 +22,7 @@ public class ToEventRegistry {
       Arrays.asList(
           new JITCompilationMapper(),
           new JVMInformationMapper(),
-          new JVMSystemPropertyMapper(),
+          new JVMSystemPropertyMapper(new AttributeValueSplitter()),
           new ThreadLockEventMapper(),
           new ValhallaVBCDetector(),
           MethodSampleMapper.forExecutionSample(),

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/AttributeValueSplitter.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/AttributeValueSplitter.java
@@ -1,0 +1,24 @@
+package com.newrelic.jfr.toevent;
+
+import com.newrelic.telemetry.Attributes;
+
+public class AttributeValueSplitter {
+
+  static final int MAX_LENGTH = 4096; // Event API attribute size limit
+
+  void maybeSplit(Attributes attr, String key, String value) {
+    int extendedCount = 0;
+    while (value.length() > MAX_LENGTH) {
+      String firstBlock = value.substring(0, MAX_LENGTH);
+      attr.put(incrementKey(extendedCount, key), firstBlock);
+      value = value.substring(MAX_LENGTH);
+      extendedCount = extendedCount + 1;
+    }
+    attr.put(incrementKey(extendedCount, key), value);
+  }
+
+  String incrementKey(int extendedCount, String key) {
+    String KEY_EXTENDED = "Extended_";
+    return extendedCount == 0 ? key : key + KEY_EXTENDED + extendedCount;
+  }
+}

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/AttributeValueSplitter.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/AttributeValueSplitter.java
@@ -5,12 +5,14 @@ import com.newrelic.telemetry.Attributes;
 public class AttributeValueSplitter {
 
   static final int MAX_LENGTH = 4096; // Event API attribute size limit
+  static final String KEY_EXTENDED = "Extended_";
 
   void maybeSplit(Attributes attr, String key, String value) {
     int extendedCount = 0;
     while (value.length() > MAX_LENGTH) {
       String firstBlock = value.substring(0, MAX_LENGTH);
       attr.put(incrementKey(extendedCount, key), firstBlock);
+
       value = value.substring(MAX_LENGTH);
       extendedCount = extendedCount + 1;
     }
@@ -18,7 +20,6 @@ public class AttributeValueSplitter {
   }
 
   String incrementKey(int extendedCount, String key) {
-    String KEY_EXTENDED = "Extended_";
     return extendedCount == 0 ? key : key + KEY_EXTENDED + extendedCount;
   }
 }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapper.java
@@ -21,6 +21,11 @@ import jdk.jfr.consumer.RecordedEvent;
 // }
 public class JVMSystemPropertyMapper implements EventToEvent {
   public static final String EVENT_NAME = "jdk.InitialSystemProperty";
+  private final AttributeValueSplitter valueSplitter;
+
+  public JVMSystemPropertyMapper(AttributeValueSplitter valueSplitter) {
+    this.valueSplitter = valueSplitter;
+  }
 
   @Override
   public String getEventName() {
@@ -32,7 +37,7 @@ public class JVMSystemPropertyMapper implements EventToEvent {
     long timestamp = event.getStartTime().toEpochMilli();
     Attributes attr = new Attributes();
     attr.put("jvmProperty", event.getString("key"));
-    attr.put("jvmPropertyValue", event.getString("value"));
+    valueSplitter.maybeSplit(attr, "jvmPropertyValue", event.getString("value"));
     return Collections.singletonList(new Event("JfrJVMInformation", attr, timestamp));
   }
 }

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/AttributeValueSplitterTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/AttributeValueSplitterTest.java
@@ -11,7 +11,7 @@ class AttributeValueSplitterTest {
 
   private AttributeValueSplitter classUnderTest;
   private final String TEST_KEY = "test_key";
-  private final String TEST_KEY_EXTENDED = TEST_KEY + "Extended_";
+  private final String TEST_KEY_EXTENDED = TEST_KEY + KEY_EXTENDED;
   private Attributes attr;
 
   @BeforeEach

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/AttributeValueSplitterTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/AttributeValueSplitterTest.java
@@ -1,0 +1,67 @@
+package com.newrelic.jfr.toevent;
+
+import static com.newrelic.jfr.toevent.AttributeValueSplitter.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.newrelic.telemetry.Attributes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AttributeValueSplitterTest {
+
+  private AttributeValueSplitter classUnderTest;
+  private final String TEST_KEY = "test_key";
+  private final String TEST_KEY_EXTENDED = TEST_KEY + "Extended_";
+  private Attributes attr;
+
+  @BeforeEach
+  void setup() {
+    this.classUnderTest = new AttributeValueSplitter();
+    this.attr = new Attributes();
+  }
+
+  @Test
+  void keyShouldNotIncrement() {
+    assertEquals(TEST_KEY, classUnderTest.incrementKey(0, TEST_KEY));
+  }
+
+  @Test
+  void keyIncrementTo3() {
+    assertEquals(TEST_KEY_EXTENDED + 3, classUnderTest.incrementKey(3, TEST_KEY));
+  }
+
+  @Test
+  void attrHasOneKeyValue() {
+    var testValue = "a";
+    testValue = testValue.repeat(MAX_LENGTH);
+    classUnderTest.maybeSplit(attr, TEST_KEY, testValue);
+    assertEquals(attr.asMap().size(), 1);
+    assertEquals(testValue, attr.asMap().get(TEST_KEY));
+  }
+
+  @Test
+  void attrHasTwoKeyValues() {
+    var expectedExtendedValue = "a";
+    var expectedFirstValue = expectedExtendedValue.repeat(MAX_LENGTH);
+    var testValue = expectedExtendedValue.repeat(MAX_LENGTH + 1);
+    var expectedExtendedKey = TEST_KEY_EXTENDED + 1;
+
+    classUnderTest.maybeSplit(attr, TEST_KEY, testValue);
+    assertEquals(attr.asMap().size(), 2);
+    assertEquals(expectedExtendedValue, attr.asMap().get(expectedExtendedKey));
+    assertEquals(expectedFirstValue, attr.asMap().get(TEST_KEY));
+  }
+
+  @Test
+  void attrHasTwo4096Values() {
+    var value = "a";
+    var expectedValue = value.repeat(MAX_LENGTH);
+    var testValue = value.repeat(MAX_LENGTH * 2);
+    var expectedExtendedKey = TEST_KEY_EXTENDED + 1;
+
+    classUnderTest.maybeSplit(attr, TEST_KEY, testValue);
+    assertEquals(attr.asMap().size(), 2);
+    assertEquals(expectedValue, attr.asMap().get(expectedExtendedKey));
+    assertEquals(expectedValue, attr.asMap().get(TEST_KEY));
+  }
+}

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapperTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapperTest.java
@@ -26,7 +26,7 @@ class JVMSystemPropertyMapperTest {
     var expectedEvent = new Event("JfrJVMInformation", expectedAttrs, startTime.toEpochMilli());
     var expected = List.of(expectedEvent);
 
-    var mapper = new JVMSystemPropertyMapper();
+    var mapper = new JVMSystemPropertyMapper(new AttributeValueSplitter());
 
     var event = mock(RecordedEvent.class);
     when(event.getStartTime()).thenReturn(startTime);


### PR DESCRIPTION
This is for #92 . 

The New Relic Event API has a limit of 4096 characters for attribute values.  Events with attribute values > 4096  are dropped by the backend and a NR Integration Error is created instead. Unfortunately, the user has no way of knowing this was dropped unless they query for this error in their account.

Some values from JFR Recorded Events end up being over 4096 characters and are dropped. For example, jfr event `jdk.InitialSystemProperty` and the value for key `java.class.path` will easily exceed 4096 characters. See the issue for an example of this value. 

The approach taken here is to split the values and create additional `Extended` attributes. Link to slack discussion about this approach is in the issue. 

```
        {
          "collector.name": "JFR-Uploader",
          "entity.guid": "MTAxMDUzODl8QVBNfEFQUExJQ0FUSU9OfDMyNzcxMzc2",
          "host.hostname": "C02WC0RNHTD8/127.0.0.1",
          "instrumentation.name": "JFR",
          "instrumentation.provider": "JFR-Uploader",
          "jvmProperty": "java.class.path",
          "jvmPropertyValue": "/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/charsets.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/cldrdata.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/dnsns.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/jaccess.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/localedata.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/nashorn.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/sunec.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/sunjce_provider.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/sunpkcs11.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/ext/zipfs.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/jce.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/jfr.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/jsse.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/management-agent.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/resources.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/jre/lib/rt.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/lib/dt.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/lib/jconsole.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/lib/sa-jdi.jar:/Users/xxia/.sdkman/candidates/java/8.0.282+8.hs-adpt/lib/tools.jar:/Users/xxia/dev/spring-petclinic/target/classes:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-actuator/2.3.3.RELEASE/spring-boot-starter-actuator-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter/2.3.3.RELEASE/spring-boot-starter-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-logging/2.3.3.RELEASE/spring-boot-starter-logging-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar:/Users/xxia/.m2/repository/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar:/Users/xxia/.m2/repository/org/apache/logging/log4j/log4j-to-slf4j/2.13.3/log4j-to-slf4j-2.13.3.jar:/Users/xxia/.m2/repository/org/apache/logging/log4j/log4j-api/2.13.3/log4j-api-2.13.3.jar:/Users/xxia/.m2/repository/org/slf4j/jul-to-slf4j/1.7.30/jul-to-slf4j-1.7.30.jar:/Users/xxia/.m2/repository/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar:/Users/xxia/.m2/repository/org/yaml/snakeyaml/1.26/snakeyaml-1.26.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-actuator-autoconfigure/2.3.3.RELEASE/spring-boot-actuator-autoconfigure-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-actuator/2.3.3.RELEASE/spring-boot-actuator-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.11.2/jackson-databind-2.11.2.jar:/Users/xxia/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.11.2/jackson-annotations-2.11.2.jar:/Users/xxia/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.11.2/jackson-datatype-jsr310-2.11.2.jar:/Users/xxia/.m2/repository/io/micrometer/micrometer-core/1.5.4/micrometer-core-1.5.4.jar:/Users/xxia/.m2/repository/org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12.jar:/Users/xxia/.m2/repository/org/latencyutils/LatencyUtils/2.0.3/LatencyUtils-2.0.3.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-cache/2.3.3.RELEASE/spring-boot-starter-cache-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-context-support/5.2.8.RELEASE/spring-context-support-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-beans/5.2.8.RELEASE/spring-beans-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-context/5.2.8.RELEASE/spring-context-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-data-jpa/2.3.3.RELEASE/spring-boot-starter-data-jpa-2.3.3.RELEASE.jar:/Users/xxia/.m2/repo",
          "jvmPropertyValueExtended1": "sitory/org/springframework/boot/spring-boot-starter-aop/2.3.3.RELEASE/spring-boot-starter-aop-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-aop/5.2.8.RELEASE/spring-aop-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/aspectj/aspectjweaver/1.9.6/aspectjweaver-1.9.6.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-jdbc/2.3.3.RELEASE/spring-boot-starter-jdbc-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/com/zaxxer/HikariCP/3.4.5/HikariCP-3.4.5.jar:/Users/xxia/.m2/repository/org/springframework/spring-jdbc/5.2.8.RELEASE/spring-jdbc-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/jakarta/transaction/jakarta.transaction-api/1.3.3/jakarta.transaction-api-1.3.3.jar:/Users/xxia/.m2/repository/jakarta/persistence/jakarta.persistence-api/2.2.3/jakarta.persistence-api-2.2.3.jar:/Users/xxia/.m2/repository/org/hibernate/hibernate-core/5.4.20.Final/hibernate-core-5.4.20.Final.jar:/Users/xxia/.m2/repository/org/jboss/logging/jboss-logging/3.4.1.Final/jboss-logging-3.4.1.Final.jar:/Users/xxia/.m2/repository/org/javassist/javassist/3.24.0-GA/javassist-3.24.0-GA.jar:/Users/xxia/.m2/repository/net/bytebuddy/byte-buddy/1.10.14/byte-buddy-1.10.14.jar:/Users/xxia/.m2/repository/antlr/antlr/2.7.7/antlr-2.7.7.jar:/Users/xxia/.m2/repository/org/jboss/jandex/2.1.3.Final/jandex-2.1.3.Final.jar:/Users/xxia/.m2/repository/com/fasterxml/classmate/1.5.1/classmate-1.5.1.jar:/Users/xxia/.m2/repository/org/dom4j/dom4j/2.1.3/dom4j-2.1.3.jar:/Users/xxia/.m2/repository/org/hibernate/common/hibernate-commons-annotations/5.1.0.Final/hibernate-commons-annotations-5.1.0.Final.jar:/Users/xxia/.m2/repository/org/springframework/data/spring-data-jpa/2.3.3.RELEASE/spring-data-jpa-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/data/spring-data-commons/2.3.3.RELEASE/spring-data-commons-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-orm/5.2.8.RELEASE/spring-orm-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-tx/5.2.8.RELEASE/spring-tx-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-aspects/5.2.8.RELEASE/spring-aspects-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-web/2.3.3.RELEASE/spring-boot-starter-web-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-json/2.3.3.RELEASE/spring-boot-starter-json-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.11.2/jackson-datatype-jdk8-2.11.2.jar:/Users/xxia/.m2/repository/com/fasterxml/jackson/module/jackson-module-parameter-names/2.11.2/jackson-module-parameter-names-2.11.2.jar:/Users/xxia/.m2/repository/org/springframework/spring-web/5.2.8.RELEASE/spring-web-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-webmvc/5.2.8.RELEASE/spring-webmvc-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-expression/5.2.8.RELEASE/spring-expression-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-jetty/2.3.3.RELEASE/spring-boot-starter-jetty-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/jakarta/servlet/jakarta.servlet-api/4.0.4/jakarta.servlet-api-4.0.4.jar:/Users/xxia/.m2/repository/jakarta/websocket/jakarta.websocket-api/1.1.2/jakarta.websocket-api-1.1.2.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-servlets/9.4.31.v20200723/jetty-servlets-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-continuation/9.4.31.v20200723/jetty-continuation-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-http/9.4.31.v20200723/jetty-http-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-util/9.4.31.v20200723/jetty-util-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-io/9.4.31.v20200723/jetty-io-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-webapp/9.4.31.v20200723/jetty-webapp-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-xml/9.4.31.v20200723/jetty-xml-9.4.31.v202",
          "jvmPropertyValueExtended2": "00723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-servlet/9.4.31.v20200723/jetty-servlet-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-security/9.4.31.v20200723/jetty-security-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-server/9.4.31.v20200723/jetty-server-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/websocket/websocket-server/9.4.31.v20200723/websocket-server-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/websocket/websocket-common/9.4.31.v20200723/websocket-common-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/websocket/websocket-api/9.4.31.v20200723/websocket-api-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/websocket/websocket-client/9.4.31.v20200723/websocket-client-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-client/9.4.31.v20200723/jetty-client-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/websocket/websocket-servlet/9.4.31.v20200723/websocket-servlet-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/websocket/javax-websocket-server-impl/9.4.31.v20200723/javax-websocket-server-impl-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-annotations/9.4.31.v20200723/jetty-annotations-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/jetty-plus/9.4.31.v20200723/jetty-plus-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/ow2/asm/asm/7.3.1/asm-7.3.1.jar:/Users/xxia/.m2/repository/org/ow2/asm/asm-commons/7.3.1/asm-commons-7.3.1.jar:/Users/xxia/.m2/repository/org/ow2/asm/asm-tree/7.3.1/asm-tree-7.3.1.jar:/Users/xxia/.m2/repository/org/ow2/asm/asm-analysis/7.3.1/asm-analysis-7.3.1.jar:/Users/xxia/.m2/repository/org/eclipse/jetty/websocket/javax-websocket-client-impl/9.4.31.v20200723/javax-websocket-client-impl-9.4.31.v20200723.jar:/Users/xxia/.m2/repository/org/glassfish/jakarta.el/3.0.3/jakarta.el-3.0.3.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-validation/2.3.3.RELEASE/spring-boot-starter-validation-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/hibernate/validator/hibernate-validator/6.1.5.Final/hibernate-validator-6.1.5.Final.jar:/Users/xxia/.m2/repository/jakarta/validation/jakarta.validation-api/2.0.2/jakarta.validation-api-2.0.2.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-starter-thymeleaf/2.3.3.RELEASE/spring-boot-starter-thymeleaf-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/thymeleaf/thymeleaf-spring5/3.0.11.RELEASE/thymeleaf-spring5-3.0.11.RELEASE.jar:/Users/xxia/.m2/repository/org/thymeleaf/thymeleaf/3.0.11.RELEASE/thymeleaf-3.0.11.RELEASE.jar:/Users/xxia/.m2/repository/org/attoparser/attoparser/2.0.5.RELEASE/attoparser-2.0.5.RELEASE.jar:/Users/xxia/.m2/repository/org/unbescape/unbescape/1.1.6.RELEASE/unbescape-1.1.6.RELEASE.jar:/Users/xxia/.m2/repository/org/thymeleaf/extras/thymeleaf-extras-java8time/3.0.4.RELEASE/thymeleaf-extras-java8time-3.0.4.RELEASE.jar:/Users/xxia/.m2/repository/jakarta/xml/bind/jakarta.xml.bind-api/2.3.3/jakarta.xml.bind-api-2.3.3.jar:/Users/xxia/.m2/repository/jakarta/activation/jakarta.activation-api/1.2.2/jakarta.activation-api-1.2.2.jar:/Users/xxia/.m2/repository/org/springframework/spring-core/5.2.8.RELEASE/spring-core-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/spring-jcl/5.2.8.RELEASE/spring-jcl-5.2.8.RELEASE.jar:/Users/xxia/.m2/repository/com/newrelic/agent/java/newrelic-api/6.3.0/newrelic-api-6.3.0.jar:/Users/xxia/.m2/repository/com/h2database/h2/1.4.200/h2-1.4.200.jar:/Users/xxia/.m2/repository/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar:/Users/xxia/.m2/repository/javax/cache/cache-api/1.1.1/cache-api-1.1.1.jar:/Users/xxia/.m2/repository/org/ehcache/ehcache/3.8.1/ehcache-3.8.1.jar:/Users/xxia/.m2/repository/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar:/Users/xxia/.m2/repository/org/glassfish/jaxb/jaxb-runtime/2.3.3/jaxb-runtime-2.3.3.jar:/Users/xxia/.m2/repository/org/glassfish/jaxb/txw2/2.3.3/txw2-2.3.3.jar:/Users/xxia/.m2/repos",
          "jvmPropertyValueExtended3": "itory/com/sun/istack/istack-commons-runtime/3.0.11/istack-commons-runtime-3.0.11.jar:/Users/xxia/.m2/repository/com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar:/Users/xxia/.m2/repository/org/webjars/webjars-locator-core/0.45/webjars-locator-core-0.45.jar:/Users/xxia/.m2/repository/io/github/classgraph/classgraph/4.8.69/classgraph-4.8.69.jar:/Users/xxia/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.11.2/jackson-core-2.11.2.jar:/Users/xxia/.m2/repository/org/webjars/jquery/2.2.4/jquery-2.2.4.jar:/Users/xxia/.m2/repository/org/webjars/jquery-ui/1.11.4/jquery-ui-1.11.4.jar:/Users/xxia/.m2/repository/org/webjars/bootstrap/3.3.6/bootstrap-3.3.6.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-devtools/2.3.3.RELEASE/spring-boot-devtools-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot/2.3.3.RELEASE/spring-boot-2.3.3.RELEASE.jar:/Users/xxia/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/2.3.3.RELEASE/spring-boot-autoconfigure-2.3.3.RELEASE.jar:newrelic/6.5.0-bughunt.jar:/Users/xxia/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/203.7148.57/IntelliJ IDEA.app/Contents/lib/idea_rt.jar",
          "nr.customEventSource": "customEventInserter",
          "timestamp": 1619047318273
        },
```

Test reported here - https://staging.one.nr/0eqwyZaz1Rn