### PR TITLE
Refactor newrelic-api to compileOnly dependency so it isn't bundled i…

### DIFF
--- a/jfr-daemon/build.gradle.kts
+++ b/jfr-daemon/build.gradle.kts
@@ -26,9 +26,17 @@ dependencies {
     api(project(":jfr-mappers"))
     implementation("org.slf4j:slf4j-simple:${slf4jVersion}");
     api("com.newrelic.telemetry:telemetry-core:${newRelicTelemetryVersion}")
-    implementation("com.newrelic.agent.java:newrelic-api:${newRelicAgentApiVersion}")
     implementation("com.squareup.okhttp3:okhttp:${okhttpVersion}")
     implementation("com.google.code.gson:gson:${gsonVersion}")
+    /*
+     * Only require the newrelic-api to compile but do not include the classes in the jfr-daemon jar.
+     * The newrelic-api will be provided on the classpath when the jfr-daemon jar is used in the agent.
+     * In other jfr-daemon use cases the newrelic-api shouldn't be necessary.
+     */
+    compileOnly("com.newrelic.agent.java:newrelic-api:${newRelicAgentApiVersion}")
+
+    // Provide the newrelic-api on the runtime classpath for tests.
+    testRuntimeOnly("com.newrelic.agent.java:newrelic-api:${newRelicAgentApiVersion}")
 }
 
 tasks.jar {

--- a/jfr-daemon/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/jfr-daemon/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,6 +1,5 @@
 package org.slf4j.impl;
 
-import com.newrelic.api.agent.Agent;
 import com.newrelic.api.agent.Logger;
 import com.newrelic.api.agent.NewRelic;
 import java.util.logging.Level;
@@ -26,9 +25,8 @@ public class StaticLoggerBinder implements LoggerFactoryBinder {
   private final ILoggerFactory loggerFactory;
 
   private StaticLoggerBinder() {
-    Agent newRelicAgent = NewRelic.getAgent();
-    if (!newRelicAgent.getClass().getName().contains("NoOpAgent")) {
-      Logger agentLogger = newRelicAgent.getLogger();
+    if (isNewRelicAgentApiPresent()) {
+      Logger agentLogger = NewRelic.getAgent().getLogger();
       loggerFactory = new AgentLoggerFactory(new AgentLoggerAdapter(agentLogger));
     } else {
       loggerFactory = new SimpleLoggerFactory();
@@ -231,6 +229,20 @@ public class StaticLoggerBinder implements LoggerFactoryBinder {
     @Override
     public void error(String s, Throwable throwable) {
       formatAndLog(Level.SEVERE, s, throwable);
+    }
+  }
+
+  /**
+   * Check if the NewRelic API is present.
+   *
+   * @return true if the NewRelic API present, else false
+   */
+  private boolean isNewRelicAgentApiPresent() {
+    try {
+      Class.forName("com.newrelic.api.agent.NewRelic");
+      return true;
+    } catch (ClassNotFoundException __) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
…n jfr-daemon jar.

This solves the problem of Java agent API classes being overwritten when the `jfr-daemon` is shadowed into the agent. We realized that the current approach has a circular dependency where if the agent API was updated it needed to be published and pulled into the `jfr-core` which would need to be published and pulled into the agent which would then need to be published again in order to prevent the APIs from being overwritten with the previous version... ugly

This PR solves the problem by making the `newrelic-api` a `compileOnly` dependency of `jfr-core` so that the API classes aren't included in the `jfr-daemon` jar but rather they're provided on the classpath when the daemon is used in the agent. This should be the only use case where the `jfr-daemon` requires Java agent APIs. Some minor refactoring was also necessary to break the agent API dependency in the JFR `StaticLoggerBinder`.

The assumption is that all uses of the agent APIs will be removed from the `jfr-agent-extension` module. Really, that that module will be refactor into some jfr tools and most existing code there will be deleted.

I've tested running the jfr-daemon embedded into the Java agent and as a standalone process, it works fine in both cases.