### PR TITLE
Issue #21 - Resolve gradle deprecation warnings.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 
 plugins {
-    id("com.github.sherter.google-java-format") version "0.8" apply false
+    id("com.github.sherter.google-java-format") version "0.9" apply false
 }
 
 allprojects {

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/ProfilerRegistry.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/ProfilerRegistry.java
@@ -40,8 +40,7 @@ public class ProfilerRegistry {
   /** For testing */
   static ProfilerRegistry create(Collection<String> eventNames) {
     List<EventToEventSummary> filtered =
-        allMappers(null)
-            .stream()
+        allMappers(null).stream()
             .filter(mapper -> eventNames.contains(mapper.getEventName()))
             .collect(toList());
     return new ProfilerRegistry(filtered);

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/ToEventRegistry.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/ToEventRegistry.java
@@ -38,8 +38,7 @@ public class ToEventRegistry {
 
   public static ToEventRegistry create(Collection<String> eventNames) {
     List<EventToEvent> filtered =
-        ALL_MAPPERS
-            .stream()
+        ALL_MAPPERS.stream()
             .filter(mapper -> eventNames.contains(mapper.getEventName()))
             .collect(toList());
     return new ToEventRegistry(filtered);

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/ToMetricRegistry.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/ToMetricRegistry.java
@@ -49,8 +49,7 @@ public class ToMetricRegistry {
 
   public static ToMetricRegistry create(Collection<String> eventNames) {
     List<EventToMetric> filtered =
-        ALL_MAPPERS
-            .stream()
+        ALL_MAPPERS.stream()
             .filter(mapper -> eventNames.contains(mapper.getEventName()))
             .collect(toList());
     return new ToMetricRegistry(filtered);
@@ -73,8 +72,7 @@ public class ToMetricRegistry {
    * @return - an optional EventToMetric.
    */
   public Optional<EventToMetric> get(String eventName) {
-    return mappers
-        .stream()
+    return mappers.stream()
         .filter(toMetric -> toMetric.getEventName().equals(eventName))
         .findFirst();
   }

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
@@ -46,8 +46,7 @@ public class ToSummaryRegistry {
   /* For testing */
   static ToSummaryRegistry create(Collection<String> eventNames) {
     List<EventToSummary> filtered =
-        allMappers()
-            .stream()
+        allMappers().stream()
             .filter(mapper -> eventNames.contains(mapper.getEventName()))
             .collect(toList());
     return new ToSummaryRegistry(filtered);

--- a/jfr-mappers/src/main/java/com/newrelic/jfr/profiler/ProfileSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/profiler/ProfileSummarizer.java
@@ -92,9 +92,7 @@ public class ProfileSummarizer implements EventToEventSummary {
   @Override
   public Stream<Event> summarize() {
     Stream<Event> eventStream =
-        stackTraceEventPerThread
-            .entrySet()
-            .stream()
+        stackTraceEventPerThread.entrySet().stream()
             .map(entry -> stackTraceToEvent(entry.getKey(), entry.getValue()))
             .flatMap(Collection::stream);
     return eventStream;

--- a/jfr-mappers/src/test/java/com/newrelic/jfr/profiler/ProfileSummarizerTest.java
+++ b/jfr-mappers/src/test/java/com/newrelic/jfr/profiler/ProfileSummarizerTest.java
@@ -124,15 +124,13 @@ class ProfileSummarizerTest {
     assertEquals(
         8,
         (int)
-            resultEvents
-                .stream()
+            resultEvents.stream()
                 .filter(
                     e -> e.getAttributes().asMap().get(THREAD_NAME).toString().equals("thread-1"))
                 .count());
     assertEquals(
         16,
-        resultEvents
-            .stream()
+        resultEvents.stream()
             .filter(e -> e.getAttributes().asMap().get(THREAD_NAME).toString().equals("thread-1"))
             .mapToInt(e -> (int) e.getAttributes().asMap().get(FLAME_VALUE))
             .sum());
@@ -159,15 +157,13 @@ class ProfileSummarizerTest {
       assertEquals(
           8,
           (int)
-              resultEvents
-                  .stream()
+              resultEvents.stream()
                   .filter(
                       e -> e.getAttributes().asMap().get(THREAD_NAME).toString().equals("thread-#"))
                   .count());
       assertEquals(
           32,
-          resultEvents
-              .stream()
+          resultEvents.stream()
               .filter(e -> e.getAttributes().asMap().get(THREAD_NAME).toString().equals("thread-#"))
               .mapToInt(e -> (int) e.getAttributes().asMap().get(FLAME_VALUE))
               .sum());


### PR DESCRIPTION
Gradle deprecation warnings caused by google-java-format-gradle-plugin version 8.0.
Upgraded google-java-format-gradle-plugin version to 9.0 which resolves the gradle deprecation warning.
Ran google-java-format-gradle-plugin to apply new formatting rules.

Addressing:
https://github.com/newrelic/newrelic-jfr-core/issues/21
https://github.com/sherter/google-java-format-gradle-plugin/issues/41

Tested:
Ran `./gradlew build --warning-mode all` locally and reviewed logs.
Logs showing no gradle deprecation warnings.