### PR TITLE
Update Realtime Profiling Instance Naming

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/DaemonConfig.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/DaemonConfig.java
@@ -33,6 +33,7 @@ public class DaemonConfig {
   private static final String DEFAULT_PROXY_SCHEME = null;
   private static final String DEFAULT_PROXY_USER = null;
   private static final String DEFAULT_PROXY_PASSWORD = null;
+  private static final String DEFAULT_HOSTNAME = "localhost";
 
   private final String apiKey;
   private final URI metricsUri;
@@ -52,6 +53,7 @@ public class DaemonConfig {
   private final String proxyPassword;
   private final String proxyScheme;
   private final String threadNamePattern;
+  private final String hostname;
 
   public DaemonConfig(Builder builder) {
     this.auditLogging = builder.auditLogging;
@@ -72,6 +74,7 @@ public class DaemonConfig {
     this.proxyPassword = builder.proxyPassword;
     this.proxyScheme = builder.proxyScheme;
     this.threadNamePattern = builder.threadNamePattern;
+    this.hostname = builder.hostname;
   }
 
   public boolean auditLogging() {
@@ -150,6 +153,8 @@ public class DaemonConfig {
     return threadNamePattern;
   }
 
+  public String getHostname() { return hostname; }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -173,6 +178,7 @@ public class DaemonConfig {
     private String proxyPassword = DEFAULT_PROXY_PASSWORD;
     private String proxyScheme = DEFAULT_PROXY_SCHEME;
     private String threadNamePattern = ThreadNameNormalizer.DEFAULT_PATTERN;
+    private String hostname = DEFAULT_HOSTNAME;
 
     public Builder auditLogging(boolean auditLogging) {
       this.auditLogging = auditLogging;
@@ -268,6 +274,11 @@ public class DaemonConfig {
       return this;
     }
 
+    public Builder hostname(String hostname) {
+      this.hostname = hostname;
+      return this;
+    }
+
     /**
      * Fetch the given envKey from the environment and, if set, convert it to another type and pass
      * it to the given builder method.
@@ -343,6 +354,9 @@ public class DaemonConfig {
         + '\''
         + ", proxyPassword='"
         + proxyPassword
+        + '\''
+        + ", hostname='"
+        + hostname
         + '\''
         + ", proxyScheme='"
         + proxyScheme

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/DaemonConfig.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/DaemonConfig.java
@@ -153,7 +153,9 @@ public class DaemonConfig {
     return threadNamePattern;
   }
 
-  public String getHostname() { return hostname; }
+  public String getHostname() {
+    return hostname;
+  }
 
   public static Builder builder() {
     return new Builder();

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EnvironmentVars.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EnvironmentVars.java
@@ -26,6 +26,7 @@ public class EnvironmentVars {
   public static final String THREAD_NAME_PATTERN = "THREAD_NAME_PATTERN";
   public static final String HARVEST_INTERVAL = "HARVEST_INTERVAL";
   public static final String QUEUE_SIZE = "QUEUE_SIZE";
+  public static final String HOSTNAME = "HOSTNAME";
 
   private EnvironmentVars() {}
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
@@ -11,7 +11,6 @@ import com.newrelic.telemetry.TelemetryClient;
 import com.newrelic.telemetry.events.EventBatchSender;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
@@ -49,17 +48,7 @@ public class SetupUtils {
             .put(AttributeNames.INSTRUMENTATION_NAME, "JFR")
             .put(AttributeNames.INSTRUMENTATION_PROVIDER, "JFR-Uploader")
             .put(AttributeNames.COLLECTOR_NAME, "JFR-Uploader");
-    String hostname;
-    if (config.getHostname() == null) {
-      try {
-        hostname = InetAddress.getLocalHost().getHostName();
-      } catch (Exception e) {
-        hostname = InetAddress.getLoopbackAddress().toString();
-      }
-    } else {
-      hostname = config.getHostname();
-    }
-    attributes.put(AttributeNames.HOSTNAME, hostname);
+
     attributes.put(AttributeNames.APP_NAME, config.getMonitoredAppName());
     attributes.put(AttributeNames.SERVICE_NAME, config.getMonitoredAppName());
     return attributes;

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
@@ -50,10 +50,14 @@ public class SetupUtils {
             .put(AttributeNames.INSTRUMENTATION_PROVIDER, "JFR-Uploader")
             .put(AttributeNames.COLLECTOR_NAME, "JFR-Uploader");
     String hostname;
-    try {
-      hostname = InetAddress.getLocalHost().toString();
-    } catch (Throwable e) {
-      hostname = InetAddress.getLoopbackAddress().toString();
+    if (config.getHostname() == null) {
+      try {
+        hostname = InetAddress.getLocalHost().getHostName();
+      } catch (Exception e) {
+        hostname = InetAddress.getLoopbackAddress().toString();
+      }
+    } else {
+      hostname = config.getHostname();
     }
     attributes.put(AttributeNames.HOSTNAME, hostname);
     attributes.put(AttributeNames.APP_NAME, config.getMonitoredAppName());

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
@@ -9,21 +9,16 @@ package com.newrelic.jfr.daemon;
 
 import static com.newrelic.jfr.daemon.AttributeNames.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.newrelic.telemetry.Attributes;
-import java.net.InetAddress;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 class SetupUtilsTest {
 
   @Test
   void buildCommonAttributes() {
-    var mockConfig = mock(DaemonConfig.class);
+    var mockConfig = Mockito.mock(DaemonConfig.class);
     when(mockConfig.getMonitoredAppName()).thenReturn("test_app_name");
     var attributesMap = SetupUtils.buildCommonAttributes(mockConfig).asMap();
     assertEquals("JFR", attributesMap.get(INSTRUMENTATION_NAME));
@@ -31,85 +26,5 @@ class SetupUtilsTest {
     assertEquals("JFR-Uploader", attributesMap.get(COLLECTOR_NAME));
     assertEquals("test_app_name", attributesMap.get(SERVICE_NAME));
     assertEquals("test_app_name", attributesMap.get(APP_NAME));
-    assertNotNull(attributesMap.get(HOSTNAME));
-  }
-
-  @Test
-  void testBuildCommonAttributesWithSpecificHostname() {
-    DaemonConfig config = mock(DaemonConfig.class);
-    when(config.getHostname()).thenReturn("test_hostname");
-    when(config.getMonitoredAppName()).thenReturn("test_app_name");
-
-    Attributes attributes = SetupUtils.buildCommonAttributes(config);
-
-    assertNotNull(attributes);
-    assertEquals("JFR", attributes.asMap().get(INSTRUMENTATION_NAME));
-    assertEquals("JFR-Uploader", attributes.asMap().get(INSTRUMENTATION_PROVIDER));
-    assertEquals("JFR-Uploader", attributes.asMap().get(COLLECTOR_NAME));
-    assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
-    assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
-    assertEquals("test_hostname", attributes.asMap().get(HOSTNAME));
-    assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
-    assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
-  }
-
-  @Test
-  void testBuildCommonAttributesWithNullConfigValueLocalHostResolution() throws Exception {
-    DaemonConfig config = mock(DaemonConfig.class);
-    when(config.getHostname()).thenReturn(null);
-    when(config.getMonitoredAppName()).thenReturn("test_app_name");
-
-    InetAddress inetAddress = mock(InetAddress.class);
-    when(inetAddress.getHostName()).thenReturn("resolved_hostname");
-
-    try (MockedStatic<InetAddress> inetAddressMockedStatic =
-        Mockito.mockStatic(InetAddress.class)) {
-      inetAddressMockedStatic.when(InetAddress::getLocalHost).thenReturn(inetAddress);
-
-      Attributes attributes = SetupUtils.buildCommonAttributes(config);
-
-      assertNotNull(attributes);
-      assertEquals("JFR", attributes.asMap().get(INSTRUMENTATION_NAME));
-      assertEquals("JFR-Uploader", attributes.asMap().get(INSTRUMENTATION_PROVIDER));
-      assertEquals("JFR-Uploader", attributes.asMap().get(COLLECTOR_NAME));
-      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
-      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
-      assertEquals("resolved_hostname", attributes.asMap().get(HOSTNAME));
-      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
-      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
-    }
-    ;
-  }
-
-  @Test
-  void testBuildCommonAttributesWithNullConfigValueLoopbackResolution() throws Exception {
-    DaemonConfig config = mock(DaemonConfig.class);
-    when(config.getHostname()).thenReturn(null);
-    when(config.getMonitoredAppName()).thenReturn("test_app_name");
-
-    InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
-
-    try (MockedStatic<InetAddress> inetAddressMockedStatic =
-        Mockito.mockStatic(InetAddress.class)) {
-      inetAddressMockedStatic
-          .when(InetAddress::getLocalHost)
-          .thenAnswer(
-              invocationOnMock -> {
-                throw new RuntimeException("Hostname resolution failed");
-              });
-      inetAddressMockedStatic.when(InetAddress::getLoopbackAddress).thenReturn(loopbackAddress);
-
-      Attributes attributes = SetupUtils.buildCommonAttributes(config);
-
-      assertNotNull(attributes);
-      assertEquals("JFR", attributes.asMap().get(INSTRUMENTATION_NAME));
-      assertEquals("JFR-Uploader", attributes.asMap().get(INSTRUMENTATION_PROVIDER));
-      assertEquals("JFR-Uploader", attributes.asMap().get(COLLECTOR_NAME));
-      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
-      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
-      assertEquals(loopbackAddress.toString(), attributes.asMap().get(HOSTNAME));
-      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
-      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
-    }
   }
 }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
@@ -10,16 +10,20 @@ package com.newrelic.jfr.daemon;
 import static com.newrelic.jfr.daemon.AttributeNames.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.newrelic.telemetry.Attributes;
+import java.net.InetAddress;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 class SetupUtilsTest {
 
   @Test
   void buildCommonAttributes() {
-    var mockConfig = Mockito.mock(DaemonConfig.class);
+    var mockConfig = mock(DaemonConfig.class);
     when(mockConfig.getMonitoredAppName()).thenReturn("test_app_name");
     var attributesMap = SetupUtils.buildCommonAttributes(mockConfig).asMap();
     assertEquals("JFR", attributesMap.get(INSTRUMENTATION_NAME));
@@ -29,4 +33,78 @@ class SetupUtilsTest {
     assertEquals("test_app_name", attributesMap.get(APP_NAME));
     assertNotNull(attributesMap.get(HOSTNAME));
   }
+
+  @Test
+  void testBuildCommonAttributesWithSpecificHostname() {
+    DaemonConfig config = mock(DaemonConfig.class);
+    when(config.getHostname()).thenReturn("test_hostname");
+    when (config.getMonitoredAppName()).thenReturn("test_app_name");
+
+    Attributes attributes = SetupUtils.buildCommonAttributes(config);
+
+    assertNotNull(attributes);
+    assertEquals("JFR", attributes.asMap().get(INSTRUMENTATION_NAME));
+    assertEquals("JFR-Uploader", attributes.asMap().get(INSTRUMENTATION_PROVIDER));
+    assertEquals("JFR-Uploader", attributes.asMap().get(COLLECTOR_NAME));
+    assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
+    assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
+    assertEquals("test_hostname", attributes.asMap().get(HOSTNAME));
+    assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
+    assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
+  }
+
+  @Test
+  void testBuildCommonAttributesWithNullConfigValueLocalHostResolution() throws Exception {
+    DaemonConfig config = mock(DaemonConfig.class);
+    when(config.getHostname()).thenReturn(null);
+    when (config.getMonitoredAppName()).thenReturn("test_app_name");
+
+    InetAddress inetAddress = mock(InetAddress.class);
+    when(inetAddress.getHostName()).thenReturn("resolved_hostname");
+
+    try (MockedStatic<InetAddress> inetAddressMockedStatic = Mockito.mockStatic(InetAddress.class)) {
+      inetAddressMockedStatic.when(InetAddress::getLocalHost).thenReturn(inetAddress);
+
+      Attributes attributes = SetupUtils.buildCommonAttributes(config);
+
+      assertNotNull(attributes);
+      assertEquals("JFR", attributes.asMap().get(INSTRUMENTATION_NAME));
+      assertEquals("JFR-Uploader", attributes.asMap().get(INSTRUMENTATION_PROVIDER));
+      assertEquals("JFR-Uploader", attributes.asMap().get(COLLECTOR_NAME));
+      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
+      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
+      assertEquals("resolved_hostname", attributes.asMap().get(HOSTNAME));
+      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
+      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
+    };
+  }
+
+  @Test
+  void testBuildCommonAttributesWithNullConfigValueLoopbackResolution() throws Exception {
+    DaemonConfig config = mock(DaemonConfig.class);
+    when(config.getHostname()).thenReturn(null);
+    when (config.getMonitoredAppName()).thenReturn("test_app_name");
+
+    InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+
+    try (MockedStatic<InetAddress> inetAddressMockedStatic = Mockito.mockStatic(InetAddress.class)) {
+      inetAddressMockedStatic.when(InetAddress::getLocalHost).thenAnswer(invocationOnMock -> {
+        throw new RuntimeException("Hostname resolution failed");
+      });
+      inetAddressMockedStatic.when(InetAddress::getLoopbackAddress).thenReturn(loopbackAddress);
+
+      Attributes attributes = SetupUtils.buildCommonAttributes(config);
+
+      assertNotNull(attributes);
+      assertEquals("JFR", attributes.asMap().get(INSTRUMENTATION_NAME));
+      assertEquals("JFR-Uploader", attributes.asMap().get(INSTRUMENTATION_PROVIDER));
+      assertEquals("JFR-Uploader", attributes.asMap().get(COLLECTOR_NAME));
+      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
+      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
+      assertEquals(loopbackAddress.toString(), attributes.asMap().get(HOSTNAME));
+      assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
+      assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
+    }
+  }
+
 }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
@@ -38,7 +38,7 @@ class SetupUtilsTest {
   void testBuildCommonAttributesWithSpecificHostname() {
     DaemonConfig config = mock(DaemonConfig.class);
     when(config.getHostname()).thenReturn("test_hostname");
-    when (config.getMonitoredAppName()).thenReturn("test_app_name");
+    when(config.getMonitoredAppName()).thenReturn("test_app_name");
 
     Attributes attributes = SetupUtils.buildCommonAttributes(config);
 
@@ -57,12 +57,13 @@ class SetupUtilsTest {
   void testBuildCommonAttributesWithNullConfigValueLocalHostResolution() throws Exception {
     DaemonConfig config = mock(DaemonConfig.class);
     when(config.getHostname()).thenReturn(null);
-    when (config.getMonitoredAppName()).thenReturn("test_app_name");
+    when(config.getMonitoredAppName()).thenReturn("test_app_name");
 
     InetAddress inetAddress = mock(InetAddress.class);
     when(inetAddress.getHostName()).thenReturn("resolved_hostname");
 
-    try (MockedStatic<InetAddress> inetAddressMockedStatic = Mockito.mockStatic(InetAddress.class)) {
+    try (MockedStatic<InetAddress> inetAddressMockedStatic =
+        Mockito.mockStatic(InetAddress.class)) {
       inetAddressMockedStatic.when(InetAddress::getLocalHost).thenReturn(inetAddress);
 
       Attributes attributes = SetupUtils.buildCommonAttributes(config);
@@ -76,21 +77,26 @@ class SetupUtilsTest {
       assertEquals("resolved_hostname", attributes.asMap().get(HOSTNAME));
       assertEquals("test_app_name", attributes.asMap().get(APP_NAME));
       assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
-    };
+    }
+    ;
   }
 
   @Test
   void testBuildCommonAttributesWithNullConfigValueLoopbackResolution() throws Exception {
     DaemonConfig config = mock(DaemonConfig.class);
     when(config.getHostname()).thenReturn(null);
-    when (config.getMonitoredAppName()).thenReturn("test_app_name");
+    when(config.getMonitoredAppName()).thenReturn("test_app_name");
 
     InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
 
-    try (MockedStatic<InetAddress> inetAddressMockedStatic = Mockito.mockStatic(InetAddress.class)) {
-      inetAddressMockedStatic.when(InetAddress::getLocalHost).thenAnswer(invocationOnMock -> {
-        throw new RuntimeException("Hostname resolution failed");
-      });
+    try (MockedStatic<InetAddress> inetAddressMockedStatic =
+        Mockito.mockStatic(InetAddress.class)) {
+      inetAddressMockedStatic
+          .when(InetAddress::getLocalHost)
+          .thenAnswer(
+              invocationOnMock -> {
+                throw new RuntimeException("Hostname resolution failed");
+              });
       inetAddressMockedStatic.when(InetAddress::getLoopbackAddress).thenReturn(loopbackAddress);
 
       Attributes attributes = SetupUtils.buildCommonAttributes(config);
@@ -106,5 +112,4 @@ class SetupUtilsTest {
       assertEquals("test_app_name", attributes.asMap().get(SERVICE_NAME));
     }
   }
-
 }


### PR DESCRIPTION
Removes the steps to add the hostname property to commonAttributes. This step will now be done in the Agent.
Issue [#1864](https://github.com/newrelic/newrelic-java-agent/issues/1864)