### PR TITLE
Remove Hostname From SetupUtils

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
@@ -11,7 +11,6 @@ import com.newrelic.telemetry.TelemetryClient;
 import com.newrelic.telemetry.events.EventBatchSender;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
@@ -49,13 +48,6 @@ public class SetupUtils {
             .put(AttributeNames.INSTRUMENTATION_NAME, "JFR")
             .put(AttributeNames.INSTRUMENTATION_PROVIDER, "JFR-Uploader")
             .put(AttributeNames.COLLECTOR_NAME, "JFR-Uploader");
-    String hostname;
-    try {
-      hostname = InetAddress.getLocalHost().toString();
-    } catch (Throwable e) {
-      hostname = InetAddress.getLoopbackAddress().toString();
-    }
-    attributes.put(AttributeNames.HOSTNAME, hostname);
     attributes.put(AttributeNames.APP_NAME, config.getMonitoredAppName());
     attributes.put(AttributeNames.SERVICE_NAME, config.getMonitoredAppName());
     return attributes;

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
@@ -9,7 +9,6 @@ package com.newrelic.jfr.daemon;
 
 import static com.newrelic.jfr.daemon.AttributeNames.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +26,5 @@ class SetupUtilsTest {
     assertEquals("JFR-Uploader", attributesMap.get(COLLECTOR_NAME));
     assertEquals("test_app_name", attributesMap.get(SERVICE_NAME));
     assertEquals("test_app_name", attributesMap.get(APP_NAME));
-    assertNotNull(attributesMap.get(HOSTNAME));
   }
 }


### PR DESCRIPTION
Removes the steps adding the hostname property to the commonAttributes. These steps will now be done in the Agent.
Issue [1864](https://github.com/newrelic/newrelic-java-agent/issues/1864)