### PR TITLE
Configure Dependabot Scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot Configuration
+#
+# This configuration file specifies the settings for Dependabot Scanning.
+# It monitors the Gradle dependencies in the specified subprojects and runs checks
+# on a weekly basis. This will only provide vulnerability alerts and will not create
+# pull requests for version updates.
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directories:
+      - "/jfr-daemon"
+      - "/jfr-link"
+      - "/jfr-mappers"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -3,11 +3,7 @@
 # Trigger: This workflow runs on every merge to the main branch.
 #
 # Purpose: It generates and submits a dependency graph to the GitHub Dependency Submission API. The graph is used to
-# trigger Dependabot Alerts for vulnerable dependencies, and to populate the Dependency Graph insights view in GitHub.
-#
-# Excludes:
-# - Test-only dependencies
-# - Module with name 'smoke-tests'
+# trigger Dependabot Alerts for vulnerable dependencies, and to populate the Dependency Graph insights view in GitHub.gi
 
 name: Dependency Submission
 
@@ -32,8 +28,6 @@ jobs:
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@d156388eb19639ec20ade50009f3d199ce1e2808 # pin@v4
         with:
-          dependency-graph-exclude-configurations: '.*[Tt]est(Compile|Runtime)Classpath'
-          dependency-graph-exclude-projects: ':smoke-tests'
           build-scan-publish: true
-          build-scan-terms-of-use-url: "https://gralde.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"


### PR DESCRIPTION
Add `dependabot.yml`:
* determines which subprojects should be scanned
* specifies frequency of scanning
* disables automatic PR's for version updates