### PR TITLE
Add service.instance.id configuration support for JFR stand alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Coming soon
 * tbd
 
+## Version 1.14.0 (2025-07-xxxxxxxxxxxxxxxxx)
+* Implement support for configuring service.instance.id value when running in stand-alone mode.
+
 ## Version 1.13.0 (2024-11-7)
 * Changed the JFR daemon `HttpPoster` implementation to use Apache Http instead of OkHttp.
 * Prevent the JFR daemon from throwing an exception when failing to delete a temp file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Coming soon
 * tbd
 
-## Version 1.14.0 (2025-07-xxxxxxxxxxxxxxxxx)
+## Version 1.14.0 (2025-07-25)
 * Implement support for configuring service.instance.id value when running in stand-alone mode.
 
 ## Version 1.13.0 (2024-11-7)

--- a/README.md
+++ b/README.md
@@ -162,12 +162,19 @@ The `jfr-daemon` standalone process has the following requirements:
 
 The minimum requirements to use the `jfr-daemon` as standalone process are as follows.
 
-Set the app name that the JFR data should be reported to, and an Insights insert key (to use an APM license key also add `export USE_LICENSE_KEY=true`):
+Set service instance id, the app name that the JFR data should be reported to, and an Insights insert key (to use an APM license key also add `export USE_LICENSE_KEY=true`):
 
 ```
 export NEW_RELIC_APP_NAME=<NAME>
 export INSIGHTS_INSERT_KEY=<KEY>
 ```
+
+The service instance id will be configured from one of the following sources, in order of precedence:
+- If the environment variable `OTEL_RESOURCE_ATTRIBUTES` is present and contains the key `service.instance.id`, the value assigned to this
+  key will be used. For example, a value of `service.name=myApp,deployment.environment=production,service.version=1.0,service.instance.id=abcd` would
+  assign the `service.instance.id` value to `abcd`.
+- If the environment variable `SERVICE_INSTANCE_ID` is present, the value of the environment variable will be used.
+- The JFR daemon will generate a random id 
 
 Start the `jfr-daemon` standalone process, it will attempt to connect to your application's remote JMX MBean server:
 
@@ -208,12 +215,19 @@ The `jfr-daemon` standalone Java agent has the following requirements:
 
 The minimum requirements to use the `jfr-daemon` as standalone Java agent are as follows.
 
-Set the app name that the JFR data should be reported to, and an Insights insert key (to use an APM license key also add `export USE_LICENSE_KEY=true`): 
+Set service instance id, the app name that the JFR data should be reported to, and an Insights insert key (to use an APM license key also add `export USE_LICENSE_KEY=true`):
 
 ```
 export NEW_RELIC_APP_NAME=<NAME>
 export INSIGHTS_INSERT_KEY=<KEY>
 ```
+
+The service instance id will be configured from one of the following sources, in order of precedence:
+- If the environment variable `OTEL_RESOURCE_ATTRIBUTES` is present and contains the key `service.instance.id`, the value assigned to this
+  key will be used. For example, a value of `service.name=myApp,deployment.environment=production,service.version=1.0,service.instance.id=abcd` would
+  assign the `service.instance.id` value to `abcd`.
+- If the environment variable `SERVICE_INSTANCE_ID` is present, the value of the environment variable will be used.
+- The JFR daemon will generate a random id
 
 Add the `-javaagent` parameter to your JVM properties:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ gsonVersion=2.8.9
 junitVersion=5.6.2
 mockitoVersion=3.9.0
 newRelicAgentApiVersion=7.4.3
-newRelicTelemetryVersion=0.16.0
+newRelicTelemetryVersion=0.17.0
 apachehttpVersion=4.5.13
 slf4jVersion=1.7.30

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/AttributeNames.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/AttributeNames.java
@@ -16,6 +16,7 @@ public class AttributeNames {
   public static final String HOSTNAME = "host.hostname";
   public static final String INSTRUMENTATION_NAME = "instrumentation.name";
   public static final String INSTRUMENTATION_PROVIDER = "instrumentation.provider";
+  public static final String SERVICE_INSTANCE_ID = "service.instance.id";
 
   private AttributeNames() {}
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EnvironmentVars.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EnvironmentVars.java
@@ -26,6 +26,8 @@ public class EnvironmentVars {
   public static final String THREAD_NAME_PATTERN = "THREAD_NAME_PATTERN";
   public static final String HARVEST_INTERVAL = "HARVEST_INTERVAL";
   public static final String QUEUE_SIZE = "QUEUE_SIZE";
+  public static final String SERVICE_INSTANCE_ID = "SERVICE_INSTANCE_ID";
+  public static final String OTEL_RESOURCE_ATTRIBUTES = "OTEL_RESOURCE_ATTRIBUTES";
 
   private EnvironmentVars() {}
 }

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EventConverter.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EventConverter.java
@@ -95,7 +95,7 @@ public class EventConverter {
    * This is gross. If the entity.guid AND service.instance.id keys are missing, we need to assign a
    * random UUID to the service.instance.id key. The presence of entity.guid indicates we're running
    * embedded in the agent. If it's not there, we're running stand alone and the service.instance.id
-   * is required.
+   * is required. If both attributes are present, entity.guid wins.
    *
    * @param attributes the Attributes instance to update
    * @return the updated Attribute instance
@@ -105,6 +105,9 @@ public class EventConverter {
     if (!attributesAsMap.containsKey(AttributeNames.ENTITY_GUID)
         && !attributesAsMap.containsKey(AttributeNames.SERVICE_INSTANCE_ID)) {
       attributes.put(AttributeNames.SERVICE_INSTANCE_ID, UUID.randomUUID().toString());
+    } else if (attributesAsMap.containsKey(AttributeNames.ENTITY_GUID)
+        && attributesAsMap.containsKey(AttributeNames.SERVICE_INSTANCE_ID)) {
+      attributes.remove(AttributeNames.SERVICE_INSTANCE_ID);
     }
 
     return attributes;

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EventConverter.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/EventConverter.java
@@ -18,6 +18,7 @@ import com.newrelic.telemetry.Attributes;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import jdk.jfr.consumer.RecordedEvent;
 import org.slf4j.Logger;
@@ -55,7 +56,7 @@ public class EventConverter {
       ToSummaryRegistry toSummaryRegistry,
       ToEventRegistry toEventRegistry,
       ProfilerRegistry profilerRegistry) {
-    this.commonAttributes = commonAttributes;
+    this.commonAttributes = validateAttributes(commonAttributes);
     this.toMetricRegistry = toMetricRegistry;
     this.toSummaryRegistry = toSummaryRegistry;
     this.toEventRegistry = toEventRegistry;
@@ -88,6 +89,25 @@ public class EventConverter {
     eventCount.clear();
 
     return batches;
+  }
+
+  /**
+   * This is gross. If the entity.guid AND service.instance.id keys are missing, we need to assign a
+   * random UUID to the service.instance.id key. The presence of entity.guid indicates we're running
+   * embedded in the agent. If it's not there, we're running stand alone and the service.instance.id
+   * is required.
+   *
+   * @param attributes the Attributes instance to update
+   * @return the updated Attribute instance
+   */
+  private Attributes validateAttributes(Attributes attributes) {
+    Map<String, Object> attributesAsMap = attributes.asMap();
+    if (!attributesAsMap.containsKey(AttributeNames.ENTITY_GUID)
+        && !attributesAsMap.containsKey(AttributeNames.SERVICE_INSTANCE_ID)) {
+      attributes.put(AttributeNames.SERVICE_INSTANCE_ID, UUID.randomUUID().toString());
+    }
+
+    return attributes;
   }
 
   private void convertAndBuffer(BufferedTelemetry batches, RecordedEvent event) {

--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/SetupUtils.java
@@ -52,6 +52,11 @@ public class SetupUtils {
             .put(AttributeNames.COLLECTOR_NAME, "JFR-Uploader");
     attributes.put(AttributeNames.APP_NAME, config.getMonitoredAppName());
     attributes.put(AttributeNames.SERVICE_NAME, config.getMonitoredAppName());
+
+    if (config.getServiceInstanceId() != null) {
+      attributes.put(AttributeNames.SERVICE_INSTANCE_ID, config.getServiceInstanceId());
+    }
+
     return attributes;
   }
 
@@ -86,6 +91,9 @@ public class SetupUtils {
     builder.maybeEnv(EnvironmentVars.THREAD_NAME_PATTERN, identity(), builder::threadNamePattern);
     builder.maybeEnv(EnvironmentVars.HARVEST_INTERVAL, Integer::parseInt, builder::harvestInterval);
     builder.maybeEnv(EnvironmentVars.QUEUE_SIZE, Integer::parseInt, builder::queueSize);
+    builder.maybeEnv(EnvironmentVars.SERVICE_INSTANCE_ID, identity(), builder::serviceInstanceId);
+    builder.maybeEnv(
+        EnvironmentVars.OTEL_RESOURCE_ATTRIBUTES, identity(), builder::otelResourceAttributes);
 
     return builder.build();
   }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/DaemonConfigTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/DaemonConfigTest.java
@@ -3,6 +3,7 @@ package com.newrelic.jfr.daemon;
 import static com.newrelic.jfr.daemon.DaemonConfig.DEFAULT_JMX_PORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -59,5 +60,38 @@ class DaemonConfigTest {
     assertFalse(config.streamFromJmx());
     config = DaemonConfig.builder().apiKey("a").useSharedFilesystem(false).build();
     assertTrue(config.streamFromJmx());
+  }
+
+  @Test
+  void assigningServiceIdFromOtelResourceString() {
+    DaemonConfig config =
+        DaemonConfig.builder()
+            .apiKey("a")
+            .otelResourceAttributes(
+                "service.name=myApp,deployment.environment=production,service.version=1.0,service.instance.id=abcd")
+            .serviceInstanceId("12345")
+            .build();
+    assertEquals("abcd", config.getServiceInstanceId());
+
+    config =
+        DaemonConfig.builder()
+            .apiKey("a")
+            .otelResourceAttributes(
+                "service.name=myApp,deployment.environment=production,service.version=1.0")
+            .serviceInstanceId("12345")
+            .build();
+    assertEquals("12345", config.getServiceInstanceId());
+  }
+
+  @Test
+  void assigningServiceIdExplicitly() {
+    DaemonConfig config = DaemonConfig.builder().apiKey("a").serviceInstanceId("12345").build();
+    assertEquals("12345", config.getServiceInstanceId());
+
+    config = DaemonConfig.builder().apiKey("a").serviceInstanceId(null).build();
+    assertNull(config.getServiceInstanceId()); // Random UUID
+
+    config = DaemonConfig.builder().apiKey("a").build();
+    assertNull(config.getServiceInstanceId()); // Random UUID
   }
 }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/DaemonConfigTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/DaemonConfigTest.java
@@ -89,9 +89,8 @@ class DaemonConfigTest {
     assertEquals("12345", config.getServiceInstanceId());
 
     config = DaemonConfig.builder().apiKey("a").serviceInstanceId(null).build();
-    assertNull(config.getServiceInstanceId()); // Random UUID
-
+    assertNull(config.getServiceInstanceId());
     config = DaemonConfig.builder().apiKey("a").build();
-    assertNull(config.getServiceInstanceId()); // Random UUID
+    assertNull(config.getServiceInstanceId());
   }
 }

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/EventConverterTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/EventConverterTest.java
@@ -8,7 +8,9 @@
 package com.newrelic.jfr.daemon;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,6 +80,20 @@ class EventConverterTest {
     assertEquals(2, metricBatch.getTelemetry().size());
     assertEquals(metric, new ArrayList<>(metricBatch.getTelemetry()).get(0));
     assertEquals(summary, new ArrayList<>(metricBatch.getTelemetry()).get(1));
+  }
+
+  @Test
+  void validateAttributesProperlyRecognizesEntityGuid() {
+    Attributes attributes = new Attributes();
+    attributes.put("entity.guid", "foo");
+
+    new EventConverter(attributes, "");
+    assertFalse(attributes.asMap().containsKey("service.entity.id"));
+
+    // Make sure we create a random UUID if entity.guid and service.entity.id are empty
+    attributes = new Attributes();
+    new EventConverter(attributes, "");
+    assertTrue(attributes.asMap().containsKey("service.instance.id"));
   }
 
   @Test

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/EventConverterTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/EventConverterTest.java
@@ -94,6 +94,13 @@ class EventConverterTest {
     attributes = new Attributes();
     new EventConverter(attributes, "");
     assertTrue(attributes.asMap().containsKey("service.instance.id"));
+
+    // Both attributes are present
+    attributes = new Attributes();
+    attributes.put("service.instance.id", "foo");
+    attributes.put("entity.guid", "bar");
+    assertFalse(attributes.asMap().containsKey("service.entity.id"));
+    assertTrue(attributes.asMap().containsKey("entity.guid"));
   }
 
   @Test

--- a/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
+++ b/jfr-daemon/src/test/java/com/newrelic/jfr/daemon/SetupUtilsTest.java
@@ -9,6 +9,7 @@ package com.newrelic.jfr.daemon;
 
 import static com.newrelic.jfr.daemon.AttributeNames.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
@@ -26,5 +27,15 @@ class SetupUtilsTest {
     assertEquals("JFR-Uploader", attributesMap.get(COLLECTOR_NAME));
     assertEquals("test_app_name", attributesMap.get(SERVICE_NAME));
     assertEquals("test_app_name", attributesMap.get(APP_NAME));
+    assertNull(attributesMap.get(SERVICE_INSTANCE_ID));
+  }
+
+  @Test
+  void buildCommonAttributesWithServiceId() {
+    var mockConfig = Mockito.mock(DaemonConfig.class);
+    when(mockConfig.getMonitoredAppName()).thenReturn("test_app_name");
+    when(mockConfig.getServiceInstanceId()).thenReturn("abcd");
+    var attributesMap = SetupUtils.buildCommonAttributes(mockConfig).asMap();
+    assertEquals("abcd", attributesMap.get(SERVICE_INSTANCE_ID));
   }
 }


### PR DESCRIPTION
To properly support JFR in stand alone mode, this PR adds support for the `service.instance.id` value, which is required by the back-end if the `entity.guid` value is absent. (`entity.guid` is present when running JFR from [within the NR APM agent](https://github.com/newrelic/newrelic-jfr-core/blob/main/README.md#new-relic-java-agent-jfr-service)).

The `service.instance.id` will be configured from one of the following sources, in order of precedence:
- If the environment variable `OTEL_RESOURCE_ATTRIBUTES` is present and contains the key `service.instance.id`, the value assigned to this  key will be used. For example, a value of `service.name=myApp,deployment.environment=production,service.version=1.0,service.instance.id=abcd` would
  assign the `service.instance.id` value to `abcd`.
- If the environment variable `SERVICE_INSTANCE_ID` is present, the value of the environment variable will be used.
- The JFR daemon will generate a random id 

Note that `service.instance.id` is __not__ required when running JFR from within the NR APM agent.

Thanks to @AravindKumar8520 for assistance