### PR TITLE
Add ZGC and Shenandoah GC reporting support

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizer.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/tosummary/BasicGarbageCollectionSummarizer.java
@@ -127,7 +127,7 @@ public final class BasicGarbageCollectionSummarizer implements EventToSummary {
         majorGcDurationSummarizer.accept(ev);
         majorGcCount.incrementAndGet();
       } else
-        // Ignore events unexpected name
+        // Ignore events with an unexpected name
         logger.warn("Ignoring unsupported " + EVENT_NAME + " event: " + name);
     }
   }


### PR DESCRIPTION
Resolves #263 

Adds support for reporting ZGC and Shenandoah GC.

ZGC did introduce ZGC generational GC. Shenandoah also introduced generational GC, but this has been removed from most JRE distros starting from v21.

Tentative mappings:

| Algorithm     | Event Name      | Maps to      |
|-------------|----------------|-------------|
| ZGC | Z | Major |
| ZGC Major | ZGC Major | Major
| ZGC Minor | ZGC Minor | Minor
| Shenandoah | Shenandoah | Major