### PR TITLE
Obfuscate all reported java sys properties

### DIFF
--- a/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapper.java
+++ b/jfr-mappers/src/main/java/com/newrelic/jfr/toevent/JVMSystemPropertyMapper.java
@@ -50,7 +50,7 @@ public class JVMSystemPropertyMapper implements EventToEvent {
       attr.put(JVM_PROPERTY, event.getString(KEY));
     }
     if (hasField(event, VALUE, SIMPLE_CLASS_NAME)) {
-      valueSplitter.maybeSplit(attr, JVM_PROPERTY_VALUE, event.getString(VALUE));
+      attr.put(JVM_PROPERTY_VALUE, "obfuscated");
     }
     return Collections.singletonList(new Event(JFR_JVM_INFORMATION, attr, timestamp));
   }


### PR DESCRIPTION
Resolves #279 

All reported system properties will now have the value of `obfuscated` regardless of the key.
