### PR TITLE
Fix: Add null check for MBeanServerConnection in JmxJfrRecorder

### DIFF
--- a/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/app/JmxJfrRecorder.java
+++ b/jfr-daemon/src/main/java/com/newrelic/jfr/daemon/app/JmxJfrRecorder.java
@@ -28,6 +28,9 @@ public class JmxJfrRecorder implements JfrRecorder {
   private final long recordingId;
 
   public JmxJfrRecorder(MBeanServerConnection connection, boolean streamFromJmx, long recordingId) {
+    if (connection == null) {
+      throw new IllegalArgumentException("MBeanServerConnection cannot be null");
+    }
     this.connection = connection;
     this.streamFromJmx = streamFromJmx;
     this.recordingId = recordingId;


### PR DESCRIPTION
## Summary

This PR adds a null check for the `MBeanServerConnection` parameter in the `JmxJfrRecorder` constructor.

## Problem

The `JmxJfrRecorder` constructor accepted a null `MBeanServerConnection` without validation. When a null connection was passed (e.g., due to connection failure or misconfiguration), subsequent calls to `connection.invoke()` would throw a `NullPointerException` with no meaningful error message, making debugging difficult.

## Solution

Added an `IllegalArgumentException` check at the beginning of the constructor that validates the `MBeanServerConnection` parameter is non-null. This provides:

- **Fail-fast behavior**: Errors are caught immediately at construction time
- **Clear error messaging**: The exception message clearly indicates what went wrong
- **Better debugging**: Developers can quickly identify misconfigurations or connection issues

## Testing

The fix can be verified by attempting to instantiate `JmxJfrRecorder` with a null connection, which will now throw an `IllegalArgumentException` with the message "MBeanServerConnection cannot be null" instead of allowing the object to be created and failing later with a `NullPointerException`.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.